### PR TITLE
fix(ci): grant contents:write/pull-requests:write to the release wrappers

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,7 +1,8 @@
 name: Prepare Release
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
prepare-release.yaml/release.yaml wrappers still had contents:read, unlike the other six repos in the platform's dependency chain. This caused prepare-release.yaml to fail at startup with 0 jobs scheduled (same root cause fixed elsewhere: a caller workflow's permissions block caps what a called reusable workflow can do).