### PR TITLE
feat(ci): push deployed image tag to sweetrpg/argocd on release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,3 +91,48 @@ jobs:
                   SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
               with:
                   environment: ${{ vars.SENTRY_ENV }}
+
+    update-deployment:
+        needs: docker
+        if: startsWith(github.ref, 'refs/tags/v')
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  app-id: ${{ secrets.SRPG_CI_APP_ID }}
+                  private-key: ${{ secrets.SRPG_CI_PRIVATE_KEY }}
+                  owner: sweetrpg
+                  repositories: argocd
+
+            - name: Checkout argocd
+              uses: actions/checkout@v7
+              with:
+                  repository: sweetrpg/argocd
+                  token: ${{ steps.app-token.outputs.token }}
+
+            - name: Bump deployed image tag
+              env:
+                  TAG: ${{ github.ref_name }}
+              run: |
+                  yq -i '.spec.source.kustomize.images[0] = "catalog-api=ghcr.io/sweetrpg/catalog-api:" + strenv(TAG)' \
+                    clusters/dev/sweetrpg-catalog/api-application.yaml
+
+            - name: Commit and push
+              env:
+                  TAG: ${{ github.ref_name }}
+                  GIT_AUTHOR_NAME: SweetRPG CI
+                  GIT_AUTHOR_EMAIL: ci@sweetrpg.com
+                  GIT_COMMITTER_NAME: SweetRPG CI
+                  GIT_COMMITTER_EMAIL: ci@sweetrpg.com
+              run: |
+                  git add clusters/dev/sweetrpg-catalog/api-application.yaml
+                  if git diff --cached --quiet; then
+                    echo "No change to deploy"
+                    exit 0
+                  fi
+                  git commit -m "chore(catalog-api): deploy ${TAG}"
+                  git push origin master


### PR DESCRIPTION
## Summary
- Replaces the Argo CD Image Updater approach (previous PR #98) with a simpler CI-driven git write-back, per discussion.
- Adds an `update-deployment` job to `docker-build.yml`, gated to real release tags only (`refs/tags/v*`). After the image is built and pushed, it checks out `sweetrpg/argocd` (using a token minted from the existing `SRPG_CI` GitHub App, scoped to that one repo), bumps `sweetrpg-catalog-api`'s `spec.source.kustomize.images` to the new tag, commits, and pushes to `master`.
- ArgoCD's app-of-apps sync (root `Application` in `sweetrpg/argocd`, applied once by hand - see that repo's README) then picks up the commit and redeploys. No Image Updater controller to install/maintain, no new deploy key on this repo.

## Test plan
- [x] `go build ./...` passes
- [ ] Confirm the `SRPG_CI` GitHub App installation includes `sweetrpg/argocd` (org settings)
- [ ] Confirm `bootstrap/root-application.yaml` has been applied to the cluster (one-time, manual, documented in `sweetrpg/argocd`'s README)
- [ ] Cut a real release and verify the `update-deployment` job runs and `sweetrpg/argocd`'s `api-application.yaml` gets the expected commit