### PR TITLE
fix: bump ImageUpdateAutomation and ExternalSecret apiVersions

### DIFF
--- a/kubernetes/base/images/automation.yaml
+++ b/kubernetes/base/images/automation.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 
 metadata:

--- a/kubernetes/overlays/dev/secrets.yaml
+++ b/kubernetes/overlays/dev/secrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -18,7 +18,7 @@ spec:
               key: Auth0
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -37,7 +37,7 @@ spec:
               key: /sweetrpg/catalog/api/db
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -65,7 +65,7 @@ spec:
                 target: HEALTH_TOKEN
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -84,7 +84,7 @@ spec:
               key: /sweetrpg/support/cache/client
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:


### PR DESCRIPTION
## Summary
- `image.toolkit.fluxcd.io/v1beta1` (ImageUpdateAutomation) no longer exists on the cluster's CRD
- `external-secrets.io/v1beta1` (ExternalSecret) is `served: false` on the cluster's CRD
- Both were hard-rejecting on apply, which blocked ArgoCD's `sweetrpg-catalog-api` sync entirely (kustomize output applies as one operation, so the whole sync failed rather than just these resources) - no namespace, no deployment ever landed.

## Test plan
- [x] `kubectl kustomize kubernetes/overlays/dev` builds clean, apiVersions verified against live CRD schema (`kubectl get crd ... -o jsonpath='{.spec.versions[*].name}'` / `.served`)
- [ ] ArgoCD sync succeeds once merged and picked up on `master`

Hotfix per this repo's git-flow: merges into `master` (where ArgoCD tracks `targetRevision`), then back-merges into `develop`.