### PR TITLE
fix: bump ExternalSecret apiVersion to v1

### DIFF
--- a/kubernetes/overlays/dev/secrets.yaml
+++ b/kubernetes/overlays/dev/secrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -18,7 +18,7 @@ spec:
               key: Auth0
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -37,7 +37,7 @@ spec:
               key: /sweetrpg/catalog/api/db
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -65,7 +65,7 @@ spec:
                 target: HEALTH_TOKEN
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
@@ -84,7 +84,7 @@ spec:
               key: /sweetrpg/support/cache/client
 
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:


### PR DESCRIPTION
## Summary
- Same root cause as the master hotfix (#102): `external-secrets.io/v1beta1` is `served: false` on the cluster's CRD, only `v1` is served.
- Applied directly to `develop` rather than merging `master` in - `master` still has the pre-ArgoCD-migration Flux image-automation manifests (`kubernetes/base/images/*.yaml`) that `develop` already removed in #98, so a straight `git merge master` tries to resurrect deleted files and conflicts across most of the repo. `develop`'s own copy of `secrets.yaml` had the same stale apiVersion independently.

## Test plan
- [x] `kubectl kustomize kubernetes/overlays/dev` builds clean
- [ ] Confirm no other divergence between master/develop needs reconciling (separate from this fix)