### PR TITLE
chore: fill repo-setup-standard gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,6 @@
 
 version: 2
 updates:
-    - package-ecosystem: "pip" # See documentation for possible values
-      directory: "/" # Location of package manifests
-      schedule:
-          interval: "weekly"
-      open-pull-requests-limit: 5
-      assignees:
-      - "paulyhedral"
     - package-ecosystem: "gomod" # See documentation for possible values
       directory: "/" # Location of package manifests
       schedule:

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -10,4 +10,6 @@ on:
 jobs:
   prepare:
     uses: sweetrpg/github-actions/.github/workflows/go-prepare-release.yaml@master
+    with:
+      project-number: 8
     secrets: inherit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Only the most recent release is supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/sweetrpg/catalog-api/security/advisories/new)
+rather than opening a public issue. You should expect an initial response within a few days.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` (modeled on `api-core.go`'s, a direct dependency of this repo)
- Remove stale `pip` ecosystem from `dependabot.yml` - this repo is Go-only, no Python manifests present
- Wire `project-number: 8` (Catalog Service) into `prepare-release.yaml` so future release PRs get added to the project board (previously defaulted to 0/skip, confirmed by the "Add PR to project" step being skipped on the 0.2.0 release run)

Everything else in the repo-setup-standard checklist (CI, branch protection rulesets, CODE_OF_CONDUCT/CONTRIBUTING/README, AGENTS.md with CLAUDE.md symlink, auto-merge enabled) was already in place.

## Test plan
- [x] `.github/dependabot.yml` still valid YAML, gomod/github-actions/devcontainers/docker ecosystems untouched
- [ ] Next `Prepare Release` run adds the release PR to https://github.com/orgs/sweetrpg/projects/8