### PR TITLE
fix(deps): bump api-core.go to v0.0.437

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
-	github.com/sweetrpg/api-core.go v0.0.436
+	github.com/sweetrpg/api-core.go v0.0.437
 	github.com/sweetrpg/catalog-data.go v0.0.21
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/swaggo/gin-swagger v1.6.1 h1:Ri06G4gc9N4t4k8hekMigJ9zKTFSlqj/9paAQCQs
 github.com/swaggo/gin-swagger v1.6.1/go.mod h1:LQ+hJStHakCWRiK/YNYtJOu4mR2FP+pxLnILT/qNiTw=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
-github.com/sweetrpg/api-core.go v0.0.436 h1:sCMdy9f82Y3RMtlQOnYljQ3dFjaLR3qvgyNJmME9nq0=
-github.com/sweetrpg/api-core.go v0.0.436/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
+github.com/sweetrpg/api-core.go v0.0.437 h1:tzR7ZzQ3Y+qnq98Gcqzp3Kjp5Xy1LGPrOSw5hrtaN0U=
+github.com/sweetrpg/api-core.go v0.0.437/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
 github.com/sweetrpg/catalog-data.go v0.0.21 h1:oXHdOOVr4Gbx/23CFun9LQh3U+zV8wupkkSfwkEuReY=
 github.com/sweetrpg/catalog-data.go v0.0.21/go.mod h1:LAOHdVL9e/ZEwUFfraAvYBTLx6nxKN/8qM4dtKZ/ftc=
 github.com/sweetrpg/catalog-objects.go v0.0.196 h1:JVHFT/sIU/jobAsgssU0YRggo2Filo64ilC/aXoEfj0=


### PR DESCRIPTION
## Summary
- Pods are stuck in `CrashLoopBackOff`: `panic: conflicting Schema URL: https://opentelemetry.io/schemas/1.41.0 and https://opentelemetry.io/schemas/1.26.0` in `api-core.go`'s `tracing.newTraceProvider`, called from this repo's `main.setupTracing`.
- Root cause (fixed upstream in sweetrpg/api-core.go#143, released as v0.0.437): `resource.Default()` reports schema `1.41.0` under the OTel SDK v1.44.0 already pinned here, but `newTraceProvider` merged it against a resource built with a hardcoded `semconv/v1.26.0` import. `resource.Merge` rejects the mismatch and the error was panicked on.
- Bumps `github.com/sweetrpg/api-core.go` v0.0.436 -> v0.0.437.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Confirmed the fix in isolation via a standalone smoke test in api-core.go (calls `newTraceProvider` directly, asserts no panic) before releasing v0.0.437
- [ ] Pods come up healthy after this deploys