### PR TITLE
fix(ci): update argocd deploy path to clusters/dev/catalog

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -119,7 +119,7 @@ jobs:
                   TAG: ${{ github.ref_name }}
               run: |
                   yq -i '.spec.source.kustomize.images[0] = "catalog-api=ghcr.io/sweetrpg/catalog-api:" + strenv(TAG)' \
-                    clusters/dev/sweetrpg-catalog/api-application.yaml
+                    clusters/dev/catalog/api-application.yaml
 
             - name: Commit and push
               env:
@@ -129,7 +129,7 @@ jobs:
                   GIT_COMMITTER_NAME: SweetRPG CI
                   GIT_COMMITTER_EMAIL: ci@sweetrpg.com
               run: |
-                  git add clusters/dev/sweetrpg-catalog/api-application.yaml
+                  git add clusters/dev/catalog/api-application.yaml
                   if git diff --cached --quiet; then
                     echo "No change to deploy"
                     exit 0


### PR DESCRIPTION
## Summary
- \`clusters/dev/sweetrpg-catalog/\` was renamed to \`clusters/dev/catalog/\` in \`sweetrpg/argocd\`, but \`docker-build.yml\`'s \`update-deployment\` job still hardcoded the old path - \`yq\` errored with \`no such file or directory\`.
- The job failure didn't block the release/Docker build/push itself, so this broke silently: the \`0.2.0\` and \`0.2.1\` releases both built and pushed images that never made it into \`argocd\` - production kept running \`v0.1.36\` (the crash-looping version) the whole time. Caught this while verifying \`v0.2.1\` actually deployed; \`v0.2.1\` was pushed to \`argocd\` manually as a stopgap.

## Test plan
- [x] Confirmed \`clusters/dev/catalog/api-application.yaml\` is the current live path via \`gh api repos/sweetrpg/argocd/git/trees/master?recursive=true\`
- [ ] Next tagged release successfully updates the image tag in argocd without manual intervention