### PR TITLE
fix(deps): bump api-core.go to v0.0.438

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
-	github.com/sweetrpg/api-core.go v0.0.437
+	github.com/sweetrpg/api-core.go v0.0.438
 	github.com/sweetrpg/catalog-data.go v0.0.21
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/swaggo/gin-swagger v1.6.1 h1:Ri06G4gc9N4t4k8hekMigJ9zKTFSlqj/9paAQCQs
 github.com/swaggo/gin-swagger v1.6.1/go.mod h1:LQ+hJStHakCWRiK/YNYtJOu4mR2FP+pxLnILT/qNiTw=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
-github.com/sweetrpg/api-core.go v0.0.437 h1:tzR7ZzQ3Y+qnq98Gcqzp3Kjp5Xy1LGPrOSw5hrtaN0U=
-github.com/sweetrpg/api-core.go v0.0.437/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
+github.com/sweetrpg/api-core.go v0.0.438 h1:bajOEANGUOkFsTj5r9epa8x8q8HPWE/zUrKk4Pdj3do=
+github.com/sweetrpg/api-core.go v0.0.438/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
 github.com/sweetrpg/catalog-data.go v0.0.21 h1:oXHdOOVr4Gbx/23CFun9LQh3U+zV8wupkkSfwkEuReY=
 github.com/sweetrpg/catalog-data.go v0.0.21/go.mod h1:LAOHdVL9e/ZEwUFfraAvYBTLx6nxKN/8qM4dtKZ/ftc=
 github.com/sweetrpg/catalog-objects.go v0.0.196 h1:JVHFT/sIU/jobAsgssU0YRggo2Filo64ilC/aXoEfj0=


### PR DESCRIPTION
## Summary
- Bumps \`github.com/sweetrpg/api-core.go\` v0.0.437 -> v0.0.438
- Fixes \`/status/health\` (the readiness probe endpoint) hanging indefinitely instead of
  respecting its timeout. Root cause (sweetrpg/api-core.go#148):
  \`HealthHandler\`'s \`ListCollectionNames\` call used \`context.TODO()\` instead of a bounded
  context, so a stalled Mongo operation could never be cancelled.
- Observed live: v0.2.1 pods sat at \`0/1 Ready\`, \`RESTARTS=0\`, no log errors - confirmed via
  \`wget --timeout=60\` from inside the pod that \`/status/health\` itself never responded, even
  though raw TCP to the Mongo Atlas shard was reachable and DNS/SRV resolution worked fine.

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` pass
- [ ] Pods flip to \`1/1 Ready\` after this deploys