### PR TITLE
Add explicit permissions to docker-build and go-docs workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,10 @@ on:
     #         - completed
     workflow_dispatch:
 
+permissions:
+    contents: read
+    packages: write
+
 jobs:
     docker:
         runs-on: ubuntu-latest

--- a/.github/workflows/go-docs.yml
+++ b/.github/workflows/go-docs.yml
@@ -10,6 +10,9 @@ on:
             - "!docs/**"
     workflow_dispatch:
 
+permissions:
+    contents: write
+
 jobs:
     tests:
         name: ${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Fixes 3 open CodeQL code-scanning alerts (actions/missing-workflow-permissions) by adding explicit top-level `permissions:` blocks to `docker-build.yml` and `go-docs.yml`.
- `docker-build.yml`: `contents: read` + `packages: write` (needed for the ghcr.io push via `GITHUB_TOKEN`).
- `go-docs.yml`: `contents: write` (needed to commit and push generated docs).

## Test plan
- [ ] CI passes on this PR
- [ ] Docker Build workflow still successfully pushes images on the next tag
- [ ] Docs workflow still successfully commits generated docs on next develop push