### PR TITLE
Fix deploy manifest path after kubernetes repo reorg

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -102,5 +102,5 @@ jobs:
         uses: sweetrpg/github-actions/.github/workflows/argocd-update-deployment.yaml@master
         with:
             image-name: catalog-api
-            manifest-path: clusters/dev/catalog/api-application.yaml
+            manifest-path: clusters/dev/catalog/services/api.yaml
         secrets: inherit


### PR DESCRIPTION
## Summary
- The argocd repo was renamed to kubernetes and clusters/dev/catalog was reorganized (moved into services/ and support/ subdirectories), which broke the update-deployment job in docker-build.yml (see run 30132009425).
- Companion fix: sweetrpg/github-actions#2 updates the reusable workflow's argocd-repo-name default from argocd to kubernetes.
- This PR updates manifest-path to the manifest's new location: clusters/dev/catalog/services/api.yaml.

## Test plan
- [ ] Tag a release and confirm the update-deployment job succeeds and opens/pushes the expected commit in kubernetes