### PR TITLE
Use ClusterIP instead of LoadBalancer for api Service

### DIFF
--- a/kubernetes/base/service.yaml
+++ b/kubernetes/base/service.yaml
@@ -12,7 +12,7 @@ spec:
         platform: sweetrpg
         package: catalog
         component: api
-    type: LoadBalancer
+    type: ClusterIP
     ports:
         - name: http
           port: 8000


### PR DESCRIPTION
## Summary
- The api Service was type: LoadBalancer, but nothing in this cluster provisions LoadBalancer IPs - all traffic reaches it via the Traefik Ingress, which routes to the Service by ClusterIP regardless of its type.
- status.loadBalancer.ingress therefore never populates, and ArgoCD's built-in Service health check treats an unfulfilled LoadBalancer as Progressing indefinitely - not a transient state, permanently stuck.
- Switches to ClusterIP, which ArgoCD considers Healthy immediately.

## Test plan
- [ ] After sync, `kubectl get svc api-v1 -n sweetrpg-catalog` shows ClusterIP with no External-IP column
- [ ] ArgoCD shows the Service (and overall Application) as Healthy, not Progressing