### PR TITLE
Fix Redis connection: wrong host + port env var collision

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -33,6 +33,7 @@ spec:
                 prometheus.io/port: '8000'
         spec:
             serviceAccountName: api
+            enableServiceLinks: false
             imagePullSecrets:
                 - name: sweetrpg-registry
             containers:

--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -18,7 +18,8 @@ data:
   JAEGER_ENDPOINT: http://jaeger-collector.observability.svc.cluster.local:9411/api/v2/spans
   OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger-collector.observability.svc.cluster.local:4318/
   SENTRY_RELEASE: "1"
-  REDIS_HOST: redis-master.sweetrpg-catalog.svc.cluster.local
+  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
+  REDIS_PORT: "6379"
   INGRESS_BASE_PATH: /0
   INGRESS_HOST: api.catalog.dev.sweetrpg.com
   INGRESS_SCHEMES: http,https


### PR DESCRIPTION
## Summary
Every cached endpoint was failing to reach Redis:
```
{"error":"dial tcp: address redis-master.sweetrpg-catalog.svc.cluster.local:tcp://10.107.124.46:6379: too many colons in address"}
```

Two compounding bugs:
1. `REDIS_HOST` was `redis-master.sweetrpg-catalog.svc.cluster.local`, which doesn't resolve - the actual Service is named `redis`, not `redis-master` (confirmed via `getent hosts` from inside a running pod).
2. `REDIS_PORT` was never set explicitly. Kubernetes auto-injects service-link env vars for every Service in the namespace, and since a Service is literally named `redis`, it injected `REDIS_PORT=tcp://10.107.124.46:6379` - colliding with the app's own intended default of `"6379"`.

## Fix
- `REDIS_HOST` -> `redis.sweetrpg-catalog.svc.cluster.local`
- `enableServiceLinks: false` on the Deployment pod spec (this app already does DNS-based service discovery; no reason to opt into the legacy env-var injection)
- `REDIS_PORT: "6379"` explicitly set as a backstop

## Test plan
- [ ] After sync, `GET /volumes` (or any cached endpoint) returns without the Redis dial error
- [ ] `kubectl exec` into a pod and confirm `env | grep REDIS` no longer shows `REDIS_PORT_6379_TCP*` / `REDIS_SERVICE_*` noise