### PR TITLE
Add CORS headers, configurable via ALLOWED_ORIGINS

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache/persistence"
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	"github.com/penglongli/gin-metrics/ginmetrics"
@@ -52,6 +53,9 @@ func main() {
 
 	setupTracing(r)
 
+	// CORS
+	setupCORS(r)
+
 	// Setup Prometheus metrics
 	setupMetrics(r)
 
@@ -83,6 +87,24 @@ func setupSwagger(r *gin.Engine) {
 	docs.SwaggerInfo.Schemes = strings.Split(util.GetEnv(apiconstants.INGRESS_SCHEMES, "http"), ",")
 	// swagger middleware to serve the API docs
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+}
+
+func setupCORS(r *gin.Engine) {
+	logging.Logger.Info("Setting up CORS...")
+
+	origins := util.GetEnv(constants.ALLOWED_ORIGINS, "")
+	if origins == "" {
+		logging.Logger.Warn("ALLOWED_ORIGINS not set, no cross-origin requests will be allowed")
+		return
+	}
+
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     strings.Split(origins, ","),
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
+		AllowCredentials: true,
+		MaxAge:           12 * time.Hour,
+	}))
 }
 
 func setupSentry() {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,7 +2,8 @@ package constants
 
 // Environment variable names
 const (
-	HEALTH_TOKEN = "HEALTH_TOKEN"
+	HEALTH_TOKEN    = "HEALTH_TOKEN"
+	ALLOWED_ORIGINS = "ALLOWED_ORIGINS"
 )
 
 // Value constants

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/getsentry/sentry-go v0.43.0
 	github.com/gin-contrib/cache v1.4.1
+	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/jsonapi v1.0.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/getsentry/sentry-go v0.43.0 h1:XbXLpFicpo8HmBDaInk7dum18G9KSLcjZiyUKS
 github.com/getsentry/sentry-go v0.43.0/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
 github.com/gin-contrib/cache v1.4.1 h1:HcLwLfw7p+FasNp5VAnFbbBj9SzB4bDtswvon7wYSg4=
 github.com/gin-contrib/cache v1.4.1/go.mod h1:tykDV+FgItJHYEO0eCasuRYsZKPPyb4BYhAjuTlG6RM=
+github.com/gin-contrib/cors v1.7.7 h1:Oh9joP463x7Mw72vhvJ61YQm8ODh9b04YR7vsOErD0Q=
+github.com/gin-contrib/cors v1.7.7/go.mod h1:K5tW0RkzJtWSiOdikXloy8VEZlgdVNpHNw8FpjUPNrE=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=


### PR DESCRIPTION
## Summary
- Adds gin-contrib/cors middleware, applied globally right after tracing setup.
- Allowed origins configured via a new ALLOWED_ORIGINS env var (comma-separated explicit allowlist - never a wildcard, so AllowCredentials can safely be on).
- If ALLOWED_ORIGINS is unset, the middleware is skipped entirely (fail closed - no cross-origin requests allowed - rather than defaulting to `*`).
- No value set in the dev overlay yet: catalog-web (the presumable consumer) doesn't exist beyond a README. Whoever stands up a frontend needs to add its origin to `kubernetes/overlays/<env>/configmaps.yaml`.
- Companion doc update: sweetrpg/platform's service-conventions.md documents this as the pattern other services should follow.

## Test plan
- [ ] `curl -H "Origin: https://example.com" -I https://api.catalog.dev.sweetrpg.com/volumes` shows no `Access-Control-Allow-Origin` header (ALLOWED_ORIGINS unset in dev)
- [ ] Once ALLOWED_ORIGINS is set to a real origin, the same request echoes that origin back in `Access-Control-Allow-Origin`