### PR TITLE
fix(k8s): update secret path for cache auth

### DIFF
--- a/kubernetes/overlays/dev/secrets.yaml
+++ b/kubernetes/overlays/dev/secrets.yaml
@@ -81,7 +81,7 @@ spec:
         creationPolicy: Owner
     dataFrom:
         - extract:
-              key: /sweetrpg/support/cache/client
+              key: /sweetrpg/catalog/cache/auth
 
 ---
 apiVersion: external-secrets.io/v1


### PR DESCRIPTION
## Summary
- Hotfix: catalog-api's `catalog-api-cache` ExternalSecret still pointed at the stale Akeyless
  key `/sweetrpg/support/cache/client` instead of `/sweetrpg/catalog/cache/auth`.
- This surfaced as a live incident after enabling Redis ACL auth on the shared catalog cache
  (support/catalog/cache): catalog-api's Redis client got `WRONGPASS`, and its known
  leak-error-into-response-body bug (#121) put that error text into every JSON:API response,
  which catalog-web's client then failed to decode ("Data corrupted at path ''").
- Already fixed on `develop` (f5f3e18) but unreleased; cherry-picked directly to `master` per
  git-flow's hotfix process rather than pulling in the ~25 other unreleased commits on develop.

## Test plan
- [x] Verified the corrected Akeyless key produces the same REDIS_PASS as catalog-web's
      `web-cache` secret and the cache's own `redis-auth` secret (matching SHA256 hash in
      Redis's ACL file).
- [ ] Confirm catalog-api pods pick up the corrected secret after this merges and ArgoCD syncs.
- [ ] Confirm `/browse` on catalog-web no longer returns the corrupted-JSON error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YTv3rHpKDFTzdRNCgze72J