### PR TITLE
fix(k8s): point OTLP tracing endpoint at Tempo

### DIFF
--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -16,7 +16,7 @@ data:
   JAEGER_SAMPLER_PARAM: "1"
   JAEGER_PROPAGATION: b3
   JAEGER_ENDPOINT: http://jaeger-collector.observability.svc.cluster.local:9411/api/v2/spans
-  OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger-collector.observability.svc.cluster.local:4318/
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo-distributor.observability.svc.cluster.local:4318/
   SENTRY_RELEASE: "1"
   REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
   REDIS_PORT: "6379"


### PR DESCRIPTION
## Summary
- \`OTEL_EXPORTER_OTLP_ENDPOINT\` pointed at \`jaeger-collector.observability.svc.cluster.local\`,
  which doesn't exist in this cluster - traces have been going nowhere.
- Repoints at \`tempo-distributor\`, whose OTLP receivers are now enabled
  (pilgrimagesoftware/flux#12). No code change needed - \`api-core.go\`'s tracing setup already
  uses the standard OTLP/HTTP env var.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YTv3rHpKDFTzdRNCgze72J