### PR TITLE
fix: tracer provider shuts down before the server ever serves a request

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -52,6 +52,7 @@ func main() {
 	// r.LoadHTMLGlob("tmpl/*")
 
 	setupTracing(r)
+	defer tracing.TeardownTracing()
 
 	// CORS
 	setupCORS(r)
@@ -181,8 +182,10 @@ func setupCache() persistence.CacheStore {
 func setupTracing(r *gin.Engine) {
 	logging.Logger.Info("Setting up tracing...")
 
+	// Teardown is deferred by the caller (main), not here - deferring it in this function
+	// would run it as soon as this function returns, shutting down the tracer provider
+	// before the server ever serves a request, silently dropping every span.
 	tracing.SetupTracing(constants.ServiceName)
-	defer tracing.TeardownTracing()
 	r.Use(otelgin.Middleware(constants.ServiceName))
 }
 


### PR DESCRIPTION
## Summary
- \`setupTracing\` deferred \`TeardownTracing()\` on its own return, not program exit - the
  tracer provider was shut down within milliseconds of startup, before \`r.Run()\` even started
  accepting connections. Every span created by \`otelgin.Middleware\` afterward hit an
  already-shutdown provider and was silently dropped - no errors anywhere, just zero traces.
- Confirmed via Tempo directly: catalog-web's traces landed fine (same OTLP setup pattern,
  same endpoint change today), catalog-api produced zero.
- Moves the defer to \`main()\`, matching the existing \`defer database.TeardownDatabase()\`
  pattern already used correctly there.

## Test plan
- [x] \`go build ./...\` and \`go vet ./...\` pass.
- [ ] Confirm catalog-api traces appear in Tempo after deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YTv3rHpKDFTzdRNCgze72J