### PR TITLE
fix(k8s): scale minReplicas to 1 to relieve node disk pressure

### DIFF
--- a/kubernetes/overlays/dev/hpa.yaml
+++ b/kubernetes/overlays/dev/hpa.yaml
@@ -10,7 +10,7 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: api-v1
-    minReplicas: 2
+    minReplicas: 1
     maxReplicas: 10
     metrics:
         - type: Resource


### PR DESCRIPTION
Temporary mitigation while investigating node-level disk pressure on kelos/kheled-zaram
(both nodes hitting ENOSPC on the partition backing projected service-account token volumes).
Fewer scheduled pod replicas across services reduces per-pod overhead contending for that
partition. Revert once the underlying disk issue is resolved.