### PR TITLE
Fix pr.yaml pointing at deleted branch ref

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate:
-    uses: sweetrpg/github-actions/.github/workflows/go-ci.yaml@3-add-code-coverage
+    uses: sweetrpg/github-actions/.github/workflows/go-ci.yaml@master
     with:
       publish-coverage: false
     secrets: inherit


### PR DESCRIPTION
pr.yaml was left pointing at github-actions@3-add-code-coverage after a throwaway
verification PR (#136) got merged instead of closed. That branch is now deleted (its own PR,
sweetrpg/github-actions#10, merged to master). master has everything that branch had, so this
just repoints back to it.

Refs sweetrpg/platform#3