### PR TITLE
Add coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SweetRPG Catalog API
 
 [![CI](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml/badge.svg)](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/sweetrpg/catalog-api/develop/.github/badges/coverage.json)](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/github/license/sweetrpg/catalog-api.svg)](https://img.shields.io/github/license/sweetrpg/catalog-api.svg)
 [![Issues](https://img.shields.io/github/issues/sweetrpg/catalog-api.svg)](https://img.shields.io/github/issues/sweetrpg/catalog-api.svg)
 [![PRs](https://img.shields.io/github/issues-pr/sweetrpg/catalog-api.svg)](https://img.shields.io/github/issues-pr/sweetrpg/catalog-api.svg)


### PR DESCRIPTION
Task 2.3 of the platform-wide code coverage rollout. go-ci.yaml writes a coverage badge back to
the branch on push (sweetrpg/github-actions#11). No permission changes needed - ci.yaml/pr.yaml
already grant contents:write.

Verified via a real push event on a throwaway branch before this PR: badge step succeeded,
correct JSON committed (0.0%, red).

Refs sweetrpg/platform#3
OpenSpec change: `openspec/changes/add-code-coverage/proposal.md` (in the `platform` umbrella repo)