### PR TITLE
Fix coverage badge URL (previous approach never worked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SweetRPG Catalog API
 
 [![CI](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml/badge.svg)](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/sweetrpg/catalog-api/develop/.github/badges/coverage.json)](https://github.com/sweetrpg/catalog-api/actions/workflows/ci.yaml)
+[![Coverage](https://img.shields.io/endpoint?url=https://sweetrpg.github.io/catalog-api/coverage-badge.json)](https://sweetrpg.github.io/catalog-api/)
 [![License](https://img.shields.io/github/license/sweetrpg/catalog-api.svg)](https://img.shields.io/github/license/sweetrpg/catalog-api.svg)
 [![Issues](https://img.shields.io/github/issues/sweetrpg/catalog-api.svg)](https://img.shields.io/github/issues/sweetrpg/catalog-api.svg)
 [![PRs](https://img.shields.io/github/issues-pr/sweetrpg/catalog-api.svg)](https://img.shields.io/github/issues-pr/sweetrpg/catalog-api.svg)


### PR DESCRIPTION
The badge in the README pointed at .github/badges/coverage.json via raw.githubusercontent.com -
that file was never actually written, because the CI step that was supposed to commit it got
rejected by this repo's PR-only ruleset (continue-on-error silently absorbed the failure).

go-ci.yaml now hosts the badge on GitHub Pages instead (sweetrpg/github-actions#12) - already
live at https://sweetrpg.github.io/catalog-api/coverage-badge.json since ci.yaml/pr.yaml already
reference @master. This PR just fixes the README URL to match.

Refs sweetrpg/platform#3
OpenSpec change: `openspec/changes/add-code-coverage/proposal.md` (in the `platform` umbrella repo)