### PR TITLE
Add overlays/local: /api/catalog on the shared Tailscale front door

### DIFF
--- a/kubernetes/overlays/local/configmaps.yaml
+++ b/kubernetes/overlays/local/configmaps.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: api-env
+
+data:
+  ENV: local
+  SERVICE_CHECK_URL: unset
+  HEALTH_CHECK_URL: unset
+  BUILD_INFO_PATH: /app/config/build-info.json
+  SERVICE_REGISTRATION_URL: "http://consul.sweetrpg-support.svc.cluster.local:1234"
+  JAEGER_SERVICE_NAME: api.sweetrpg-catalog
+  JAEGER_SAMPLER_TYPE: ratelimiting
+  JAEGER_SAMPLER_PARAM: "1"
+  JAEGER_PROPAGATION: b3
+  JAEGER_ENDPOINT: http://jaeger-collector.observability.svc.cluster.local:9411/api/v2/spans
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo-distributor.observability.svc.cluster.local:4318/
+  PYROSCOPE_SERVER_ADDRESS: http://pyroscope.observability.svc.cluster.local:4040
+  PYROSCOPE_TENANT_ID: psw
+  SENTRY_RELEASE: "1"
+  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
+  REDIS_PORT: "6379"
+  # Traefik strips /api/catalog/0 (or /1) before the request reaches this app (see
+  # middlewares.yaml) - every self-referencing link this app generates needs the full prefix
+  # added back, not just the /0 dev overlay uses (this overlay shares one host with every other
+  # app, unlike dev's dedicated api.catalog.dev.sweetrpg.com).
+  INGRESS_BASE_PATH: /api/catalog/0
+  INGRESS_HOST: sweetrpg-local.curlew-smoot.ts.net
+  INGRESS_SCHEMES: https

--- a/kubernetes/overlays/local/ingress.yaml
+++ b/kubernetes/overlays/local/ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: api-v1
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: sweetrpg-catalog-strip-prefix-v1@kubernetescrd
+    kubernetes.io/ingress.class: traefik
+    # TLS is terminated once, upstream, by the Tailscale Kubernetes operator's Ingress in
+    # support/config/K8s/traefik/overlays/minikube (traefik-tailscale) - this hop is plain HTTP
+    # inside the cluster, no cert-manager/websecure annotations needed here.
+
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: sweetrpg-local.curlew-smoot.ts.net
+      http:
+        paths:
+          - pathType: Prefix
+            path: /api/catalog
+            backend:
+              service:
+                name: api-v1
+                port:
+                  name: http

--- a/kubernetes/overlays/local/kustomization.yaml
+++ b/kubernetes/overlays/local/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sweetrpg-catalog
+
+resources:
+    - ../../base
+    - configmaps.yaml
+    - secrets.yaml
+    - ingress.yaml
+    - middlewares.yaml
+    - pod-monitor.yaml
+
+labels:
+    - pairs:
+          app: api
+          version: v1
+          platform: sweetrpg
+          package: catalog
+          component: api
+
+generatorOptions:
+    disableNameSuffixHash: true
+
+images:
+    - name: catalog-api
+      newName: ghcr.io/sweetrpg/catalog-api
+      newTag: v0.2.2

--- a/kubernetes/overlays/local/middlewares.yaml
+++ b/kubernetes/overlays/local/middlewares.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+
+metadata:
+  name: strip-prefix-v1
+
+spec:
+  # Unlike the dev overlay's strip-prefix-v1 (which only strips the bare /0 or /1 version
+  # segment, since dev gives this service its own host with no other path prefix), this overlay
+  # shares one host across every app - strip the full /api/catalog/0 or /api/catalog/1 prefix so
+  # the app still sees its normal unprefixed routes.
+  stripPrefix:
+    prefixes:
+      - /api/catalog/0
+      - /api/catalog/1

--- a/kubernetes/overlays/local/pod-monitor.yaml
+++ b/kubernetes/overlays/local/pod-monitor.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+
+metadata:
+  name: sweetrpg-catalog-api
+  labels:
+    release: prometheus
+
+spec:
+  podMetricsEndpoints:
+    - port: http
+  selector:
+    matchLabels:
+        platform: sweetrpg
+        app: api
+        package: catalog
+        component: api
+  namespaceSelector:
+    matchNames:
+      - sweetrpg-catalog

--- a/kubernetes/overlays/local/secrets.yaml
+++ b/kubernetes/overlays/local/secrets.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+    name: catalog-api-auth
+
+spec:
+    refreshInterval: "1h"
+    secretStoreRef:
+        name: akeyless
+        kind: ClusterSecretStore
+    target:
+        name: api-auth
+        creationPolicy: Owner
+    dataFrom:
+        - extract:
+              key: Auth0
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+    name: catalog-api-db
+
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: akeyless
+        kind: ClusterSecretStore
+    target:
+        name: api-db
+        creationPolicy: Owner
+    dataFrom:
+        - extract:
+              key: /sweetrpg/catalog/api/db
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+    name: catalog-api-misc
+
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: akeyless
+        kind: ClusterSecretStore
+    target:
+        name: api-misc
+        creationPolicy: Owner
+    dataFrom:
+        - extract:
+              key: /sweetrpg/catalog/api/misc
+        - sourceRef:
+            generatorRef:
+                apiVersion: generators.external-secrets.io/v1alpha1
+                kind: Password
+                name: "catalog-api-health-token"
+          rewrite:
+            - regexp:
+                source: "(.*)"
+                target: HEALTH_TOKEN
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+    name: catalog-api-cache
+
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: akeyless
+        kind: ClusterSecretStore
+    target:
+        name: api-cache
+        creationPolicy: Owner
+    dataFrom:
+        - extract:
+              key: /sweetrpg/catalog/cache/auth
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+    name: catalog-api-files
+
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: akeyless
+        kind: ClusterSecretStore
+    target:
+        name: api-files
+        creationPolicy: Owner
+        template:
+            type: Opaque
+            data:
+                newrelic.ini: "{{ .contents | toString }}"
+    data:
+        - secretKey: contents
+          remoteRef:
+              key: NewRelic
+
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+
+metadata:
+  name: catalog-api-health-token
+
+spec:
+  length: 53
+  digits: 5
+  symbols: 5
+  symbolCharacters: "-_$@"
+  noUpper: false
+  allowRepeat: true


### PR DESCRIPTION
## Summary
No local overlay existed for this service. Add one modeled on overlays/dev but routed through Traefik behind the shared traefik-tailscale front door (sweetrpg/config#1) at `/api/catalog` on `sweetrpg-local.<tailnet>.ts.net`, rather than dev's own dedicated `api.catalog.dev.sweetrpg.com`.

- `strip-prefix-v1` strips the full `/api/catalog/0` or `/api/catalog/1` prefix (instead of dev's bare `/0`/`/1`), since this overlay shares one host with every other app.
- `INGRESS_BASE_PATH` becomes `/api/catalog/0` so self-referencing links this app generates round-trip correctly.

## Test plan
- [x] `kubectl kustomize kubernetes/overlays/local` renders cleanly
- [ ] Apply to a minikube cluster with the Tailscale operator + Traefik (sweetrpg/config#1) installed; confirm `sweetrpg-local.<tailnet>.ts.net/api/catalog/0/...` reaches catalog-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CVTakt56gYqdT1BCcfePs