### PR TITLE
Make Redis-backed caching and rate limiting actually work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,18 +13,31 @@ contributions, persons, publishers, reviews, studios, systems). It's a thin Gin-
 
 - `catalog-data.go`'s Volume entity is the only one with a write path, and `Update`/`Delete`
   are still `// TODO` stubs there. Every other entity is read-only.
-- No test coverage in `server/` or `cmd/` - the handler bugs found in this repo's initial
-  hardening pass (wrong function names, cross-entity mix-ups, missing `return` after 404) were
-  caught by code review, not by tests. Testing these handlers meaningfully needs either
-  MongoDB-backed integration tests (matching `catalog-data.go`'s pattern) or refactoring for
-  dependency injection - neither has been done yet.
+- No test coverage in `server/` - the handler bugs found in this repo's initial hardening pass
+  (wrong function names, cross-entity mix-ups, missing `return` after 404) were caught by code
+  review, not by tests. Testing these handlers meaningfully needs either MongoDB-backed
+  integration tests (matching `catalog-data.go`'s pattern) or refactoring for dependency
+  injection - neither has been done yet. `cmd/catalog-api`, `cachettl`, and `ratelimit` do have
+  unit test coverage (the latter two use `alicebob/miniredis` rather than a real Redis).
 - This repo currently cannot build against the *published* versions of `catalog-data.go`
   (a bug there is fixed on `develop` but unreleased) - see CHANGELOG.md.
+- The `DISTRIBUTED_RATE_LIMIT_ENABLED` per-client rate limiter hasn't been validated against a
+  real dev workload yet - the legacy process-wide limiter is still the default. See
+  `openspec/changes/catalog-api-caching-rate-limiting` (in the `platform` umbrella repo) for the
+  rest of that rollout.
 
 ## Dependencies
 
 Depends on `api-core.go`, `catalog-data.go`, `common.go`, and `mongodb.go`. Nothing depends on
 this repo - it's the top of the catalog dependency chain.
+
+## Caching and Rate Limiting
+
+See `platform/docs/service-conventions.md`'s Caching and Rate limiting sections for the
+Redis-backed cache readiness check, per-route TTL (`CACHE_TTLS`/`CACHE_DEFAULT_TTL`), and the
+distributed rate limiter (`DISTRIBUTED_RATE_LIMIT_ENABLED`,
+`RATE_LIMIT_CHEAP`/`RATE_LIMIT_CHEAP_WINDOW_SECONDS`,
+`RATE_LIMIT_STANDARD`/`RATE_LIMIT_STANDARD_WINDOW_SECONDS`) that replaces it once validated.
 
 ## Committing Code
 

--- a/cachettl/cachettl.go
+++ b/cachettl/cachettl.go
@@ -1,0 +1,69 @@
+// Package cachettl resolves the cache TTL for a given route group, loaded once at startup
+// from the CACHE_TTLS env var so slower-changing entities and faster-changing ones aren't
+// forced onto the same cache policy.
+package cachettl
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sweetrpg/catalog-api/constants"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/common.go/util"
+)
+
+const defaultTTLFallback = time.Hour
+
+// Config resolves a per-route-group TTL, falling back to a configured default for any route
+// group without an explicit entry.
+type Config struct {
+	ttls       map[string]time.Duration
+	defaultTTL time.Duration
+}
+
+// Load parses CACHE_TTLS ("route=duration,route=duration", e.g. "licenses=30m,volumes=15m")
+// and CACHE_DEFAULT_TTL (a single duration string) from the environment. Malformed entries are
+// logged and skipped rather than failing startup.
+func Load() Config {
+	defaultTTL := defaultTTLFallback
+	if raw := util.GetEnv(constants.CACHE_DEFAULT_TTL, ""); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil {
+			defaultTTL = d
+		} else {
+			logging.Logger.Warn("Invalid CACHE_DEFAULT_TTL, using fallback default",
+				"value", raw, "fallback", defaultTTLFallback.String(), "error", err.Error())
+		}
+	}
+
+	ttls := map[string]time.Duration{}
+	raw := util.GetEnv(constants.CACHE_TTLS, "")
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		route, value, found := strings.Cut(entry, "=")
+		if !found {
+			logging.Logger.Warn("Invalid CACHE_TTLS entry, expected route=duration", "entry", entry)
+			continue
+		}
+		d, err := time.ParseDuration(strings.TrimSpace(value))
+		if err != nil {
+			logging.Logger.Warn("Invalid CACHE_TTLS duration, skipping entry",
+				"entry", entry, "error", err.Error())
+			continue
+		}
+		ttls[strings.TrimSpace(route)] = d
+	}
+
+	return Config{ttls: ttls, defaultTTL: defaultTTL}
+}
+
+// TTL returns the configured TTL for the given route group, or the configured default if the
+// route group has no explicit entry.
+func (c Config) TTL(route string) time.Duration {
+	if d, ok := c.ttls[route]; ok {
+		return d
+	}
+	return c.defaultTTL
+}

--- a/cachettl/cachettl_test.go
+++ b/cachettl/cachettl_test.go
@@ -1,0 +1,72 @@
+package cachettl
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sweetrpg/catalog-api/constants"
+	"github.com/sweetrpg/common.go/logging"
+)
+
+func TestMain(m *testing.M) {
+	// Package logging's zero-value Logger blocks on any call until Init() runs - Load() logs
+	// warnings on malformed input, so tests need a real logger.
+	logging.Init()
+	os.Exit(m.Run())
+}
+
+func TestTTLReturnsExplicitEntry(t *testing.T) {
+	t.Setenv(constants.CACHE_TTLS, "licenses=30m,volumes=15m")
+	cfg := Load()
+
+	if got := cfg.TTL("licenses"); got != 30*time.Minute {
+		t.Fatalf("TTL(licenses) = %v, want 30m", got)
+	}
+	if got := cfg.TTL("volumes"); got != 15*time.Minute {
+		t.Fatalf("TTL(volumes) = %v, want 15m", got)
+	}
+}
+
+func TestTTLFallsBackToDefaultForUnlistedRoute(t *testing.T) {
+	t.Setenv(constants.CACHE_TTLS, "licenses=30m")
+	cfg := Load()
+
+	if got := cfg.TTL("reviews"); got != defaultTTLFallback {
+		t.Fatalf("TTL(reviews) = %v, want fallback default %v", got, defaultTTLFallback)
+	}
+}
+
+func TestTTLUsesConfiguredDefault(t *testing.T) {
+	t.Setenv(constants.CACHE_TTLS, "")
+	t.Setenv(constants.CACHE_DEFAULT_TTL, "5m")
+	cfg := Load()
+
+	if got := cfg.TTL("anything"); got != 5*time.Minute {
+		t.Fatalf("TTL(anything) = %v, want 5m", got)
+	}
+}
+
+func TestLoadSkipsMalformedEntries(t *testing.T) {
+	t.Setenv(constants.CACHE_TTLS, "licenses=30m,not-a-valid-entry,reviews=notaduration,studios=10m")
+	cfg := Load()
+
+	if got := cfg.TTL("licenses"); got != 30*time.Minute {
+		t.Fatalf("TTL(licenses) = %v, want 30m", got)
+	}
+	if got := cfg.TTL("studios"); got != 10*time.Minute {
+		t.Fatalf("TTL(studios) = %v, want 10m", got)
+	}
+	if got := cfg.TTL("reviews"); got != defaultTTLFallback {
+		t.Fatalf("TTL(reviews) = %v, want fallback default (malformed entry skipped)", got)
+	}
+}
+
+func TestLoadSkipsInvalidDefaultTTL(t *testing.T) {
+	t.Setenv(constants.CACHE_DEFAULT_TTL, "not-a-duration")
+	cfg := Load()
+
+	if got := cfg.TTL("anything"); got != defaultTTLFallback {
+		t.Fatalf("TTL(anything) = %v, want fallback default %v", got, defaultTTLFallback)
+	}
+}

--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/gomodule/redigo/redis"
 	"github.com/grafana/pyroscope-go"
 	"github.com/joho/godotenv"
 	"github.com/penglongli/gin-metrics/ginmetrics"
@@ -22,15 +24,23 @@ import (
 	apiconstants "github.com/sweetrpg/api-core.go/constants"
 	"github.com/sweetrpg/api-core.go/tracing"
 	"github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-api/constants"
 	"github.com/sweetrpg/catalog-api/docs"
+	"github.com/sweetrpg/catalog-api/ratelimit"
+	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/catalog-api/server"
 	"github.com/sweetrpg/common.go/logging"
 	"github.com/sweetrpg/common.go/util"
 	"github.com/sweetrpg/mongodb.go/database"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
-	"golang.org/x/time/rate"
+	xrate "golang.org/x/time/rate"
 )
+
+// redisConnectTimeout bounds startup/readiness pings to Redis so a stalled connection fails
+// fast instead of hanging past the caller's own timeout (same rationale as api-core.go's
+// healthCheckTimeout for Mongo).
+const redisConnectTimeout = 5 * time.Second
 
 // @title Catalog API service
 // @version 1.0
@@ -65,7 +75,12 @@ func main() {
 	// Setup Prometheus metrics
 	setupMetrics(r)
 
-	cache := setupCache()
+	redisPool := setupRedisPool()
+	if redisPool != nil {
+		defer redisPool.Close()
+	}
+	cache := setupCache(redisPool)
+	ttls := cachettl.Load()
 
 	database.SetupDatabase()
 	defer database.TeardownDatabase()
@@ -77,9 +92,9 @@ func main() {
 	setupSwagger(r)
 
 	// Add rate limiter
-	r.Use(RateLimiter())
+	r.Use(RateLimiter(redisPool))
 
-	server.SetupHandlers(r, cache)
+	server.SetupHandlers(r, cache, ttls)
 
 	_ = r.Run(util.GetEnv(apiconstants.BIND_ADDRESS, ":8000"))
 }
@@ -194,18 +209,63 @@ func setupAcuator(r *gin.Engine) {
 	r.GET("/actuator/*endpoint", ginActuatorHandler)
 }
 
-func setupCache() persistence.CacheStore {
+// setupRedisPool builds a shared redigo connection pool for both the rate limiter's counters
+// and the cache's startup connectivity check, when REDIS_HOST is configured. Returns nil when
+// no Redis is configured, so the service runs entirely without an external dependency.
+func setupRedisPool() *redis.Pool {
+	redisHost, found := os.LookupEnv(apiconstants.REDIS_HOST)
+	if !found {
+		return nil
+	}
+
+	redisPort := util.GetEnv(apiconstants.REDIS_PORT, "6379")
+	redisPass := os.Getenv(apiconstants.REDIS_PASS)
+	addr := fmt.Sprintf("%s:%s", redisHost, redisPort)
+
+	return &redis.Pool{
+		MaxIdle:     5,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("tcp", addr, redis.DialConnectTimeout(redisConnectTimeout))
+			if err != nil {
+				return nil, err
+			}
+			if redisPass != "" {
+				if _, err := c.Do("AUTH", redisPass); err != nil {
+					_ = c.Close()
+					return nil, err
+				}
+			}
+			return c, nil
+		},
+	}
+}
+
+// setupCache builds the response cache store and, when REDIS_HOST is configured, verifies
+// connectivity before the service reports ready. A configured-but-unreachable Redis fails the
+// readiness probe (see readiness.CacheReady, consumed by /status/health) instead of silently
+// falling back to uncached behavior.
+func setupCache(redisPool *redis.Pool) persistence.CacheStore {
 	logging.Logger.Info("Setting up query cache...")
 
-	var cache persistence.CacheStore
 	redisHost, found := os.LookupEnv(apiconstants.REDIS_HOST)
-	if found {
-		redisPort := util.GetEnv(apiconstants.REDIS_PORT, "6379")
-		// TODO: redisDb := util.GetEnv(apiconstants.REDIS_DB, "0")
-		redisPass := os.Getenv(apiconstants.REDIS_PASS)
-		cache = persistence.NewRedisCache(fmt.Sprintf("%s:%s", redisHost, redisPort), redisPass, time.Hour)
+	if !found {
+		readiness.SetCacheReady(true)
+		return persistence.NewInMemoryStore(time.Hour)
+	}
+
+	redisPort := util.GetEnv(apiconstants.REDIS_PORT, "6379")
+	redisPass := os.Getenv(apiconstants.REDIS_PASS)
+	cache := persistence.NewRedisCache(fmt.Sprintf("%s:%s", redisHost, redisPort), redisPass, time.Hour)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisConnectTimeout)
+	defer cancel()
+	if err := ratelimit.Ping(ctx, redisPool); err != nil {
+		logging.Logger.Error("REDIS_HOST is configured but unreachable; failing readiness instead of silently serving uncached responses",
+			"redis_host", redisHost, "error", err.Error())
+		readiness.SetCacheReady(false)
 	} else {
-		cache = persistence.NewInMemoryStore(time.Hour)
+		readiness.SetCacheReady(true)
 	}
 
 	return cache
@@ -231,15 +291,95 @@ func setupMetrics(r *gin.Engine) {
 	m.Use(r)
 }
 
-func RateLimiter() gin.HandlerFunc {
-	limiter := rate.NewLimiter(1, util.GetEnvInt(apiconstants.RATE_LIMIT, 10))
+// rateLimitTierFor groups routes into a looser "cheap" tier (shallow status endpoints) and a
+// stricter "standard" tier (everything else), per design.md's decision to start with two tiers
+// keyed by route cost rather than one entry per resource.
+func rateLimitTierFor(path string) string {
+	if strings.HasPrefix(path, "/status/") {
+		return "cheap"
+	}
+	return "standard"
+}
+
+// rateLimitClientKey identifies the caller for per-client limiting: API key if the client sent
+// one, otherwise client IP. This doesn't introduce a new auth mechanism - it keys off whatever
+// identity already exists on the request (see design.md's open question on API-key issuance).
+func rateLimitClientKey(c *gin.Context) string {
+	if apiKey := c.GetHeader("X-API-Key"); apiKey != "" {
+		return "key:" + apiKey
+	}
+	return "ip:" + c.ClientIP()
+}
+
+// RateLimiter selects between the new Redis-backed per-client limiter and the legacy
+// process-wide token bucket, gated by DISTRIBUTED_RATE_LIMIT_ENABLED so the new limiter can be
+// validated in dev before the old one is removed (tasks 4.5-4.6).
+func RateLimiter(redisPool *redis.Pool) gin.HandlerFunc {
+	distributedEnabled, _ := strconv.ParseBool(util.GetEnv(constants.DISTRIBUTED_RATE_LIMIT_ENABLED, "false"))
+	if distributedEnabled && redisPool != nil {
+		return distributedRateLimiter(redisPool)
+	}
+
+	if distributedEnabled && redisPool == nil {
+		logging.Logger.Warn("DISTRIBUTED_RATE_LIMIT_ENABLED is set but REDIS_HOST is not; falling back to the process-wide limiter")
+	}
+
+	return globalRateLimiter()
+}
+
+// distributedRateLimiter enforces per-client, per-tier limits backed by Redis, consistent
+// across replicas. Fails closed (503) if the Redis backend is unreachable, rather than letting
+// requests through unlimited during an outage.
+func distributedRateLimiter(redisPool *redis.Pool) gin.HandlerFunc {
+	limiter := ratelimit.New(redisPool, map[string]ratelimit.Tier{
+		"cheap": {
+			Limit:  util.GetEnvInt(constants.RATE_LIMIT_CHEAP, 120),
+			Window: util.GetEnvInt(constants.RATE_LIMIT_CHEAP_WINDOW, 60),
+		},
+		"standard": {
+			Limit:  util.GetEnvInt(constants.RATE_LIMIT_STANDARD, 30),
+			Window: util.GetEnvInt(constants.RATE_LIMIT_STANDARD_WINDOW, 60),
+		},
+	})
+
+	return func(c *gin.Context) {
+		tier := rateLimitTierFor(c.Request.URL.Path)
+		clientKey := rateLimitClientKey(c)
+
+		allowed, err := limiter.Allow(c.Request.Context(), clientKey, tier)
+		if err != nil {
+			logging.Logger.Error("Rate-limit backend unreachable; rejecting request (fail closed)", "error", err.Error())
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, vo.ErrorVO{
+				Error:   constants.ErrorRateLimitUnavailable,
+				Message: "Rate limiting is temporarily unavailable",
+			})
+			return
+		}
+		if !allowed {
+			logging.Logger.Warn("Rate limit exceeded", "client", clientKey, "tier", tier, "path", c.Request.URL.Path)
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, vo.ErrorVO{
+				Error:   apiconstants.ErrorRateLimited,
+				Message: "Limit exceeded",
+			})
+			return
+		}
+		c.Next()
+	}
+}
+
+// globalRateLimiter is the legacy process-wide token bucket: one shared limit across every
+// client and route, effectively N times looser with N replicas since each pod holds its own
+// bucket. Kept behind the DISTRIBUTED_RATE_LIMIT_ENABLED toggle until the new limiter is
+// validated in dev (task 4.6 removes this once that happens).
+func globalRateLimiter() gin.HandlerFunc {
+	limiter := xrate.NewLimiter(1, util.GetEnvInt(apiconstants.RATE_LIMIT, 10))
 
 	return func(c *gin.Context) {
 		if limiter.Allow() {
 			c.Next()
 		} else {
 			logging.Logger.Warn(fmt.Sprintf("Rate limit exceeded for request: %v", c.Request))
-			c.JSON(http.StatusTooManyRequests, vo.ErrorVO{
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, vo.ErrorVO{
 				Error:   apiconstants.ErrorRateLimited,
 				Message: "Limit exceeded",
 			})

--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	redisPool := setupRedisPool()
 	if redisPool != nil {
-		defer redisPool.Close()
+		defer func() { _ = redisPool.Close() }()
 	}
 	cache := setupCache(redisPool)
 	ttls := cachettl.Load()

--- a/cmd/catalog-api/main_test.go
+++ b/cmd/catalog-api/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	apiconstants "github.com/sweetrpg/api-core.go/constants"
+	"github.com/sweetrpg/catalog-api/readiness"
+	"github.com/sweetrpg/common.go/logging"
+)
+
+func TestMain(m *testing.M) {
+	logging.Init()
+	os.Exit(m.Run())
+}
+
+func TestSetupCacheReportsReadyWhenRedisReachable(t *testing.T) {
+	mr := miniredis.RunT(t)
+	t.Setenv(apiconstants.REDIS_HOST, mr.Host())
+	t.Setenv(apiconstants.REDIS_PORT, mr.Port())
+
+	pool := setupRedisPool()
+	t.Cleanup(func() { _ = pool.Close() })
+
+	setupCache(pool)
+
+	if !readiness.CacheReady() {
+		t.Fatal("readiness.CacheReady() = false, want true when Redis is reachable")
+	}
+}
+
+func TestSetupCacheFailsReadinessWhenRedisUnreachable(t *testing.T) {
+	mr := miniredis.RunT(t)
+	host, port := mr.Host(), mr.Port()
+	mr.Close()
+
+	t.Setenv(apiconstants.REDIS_HOST, host)
+	t.Setenv(apiconstants.REDIS_PORT, port)
+
+	pool := setupRedisPool()
+	t.Cleanup(func() { _ = pool.Close() })
+
+	setupCache(pool)
+
+	if readiness.CacheReady() {
+		t.Fatal("readiness.CacheReady() = true, want false when REDIS_HOST is configured but unreachable")
+	}
+}
+
+func TestSetupCacheReportsReadyWhenRedisNotConfigured(t *testing.T) {
+	// Ensure no leftover REDIS_HOST from another test/process poisons this case.
+	previous, wasSet := os.LookupEnv(apiconstants.REDIS_HOST)
+	_ = os.Unsetenv(apiconstants.REDIS_HOST)
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv(apiconstants.REDIS_HOST, previous)
+		}
+	})
+
+	setupCache(nil)
+
+	if !readiness.CacheReady() {
+		t.Fatal("readiness.CacheReady() = false, want true when no cache backend is configured (in-memory store, no dependency to fail)")
+	}
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -6,9 +6,25 @@ const (
 	ALLOWED_ORIGINS          = "ALLOWED_ORIGINS"
 	PYROSCOPE_SERVER_ADDRESS = "PYROSCOPE_SERVER_ADDRESS"
 	PYROSCOPE_TENANT_ID      = "PYROSCOPE_TENANT_ID"
+
+	// CACHE_TTLS maps route group to TTL, e.g. "licenses=30m,volumes=15m".
+	// Route groups not listed fall back to CACHE_DEFAULT_TTL.
+	CACHE_TTLS        = "CACHE_TTLS"
+	CACHE_DEFAULT_TTL = "CACHE_DEFAULT_TTL"
+
+	// DISTRIBUTED_RATE_LIMIT_ENABLED toggles the Redis-backed per-client limiter on in
+	// place of the process-wide golang.org/x/time/rate limiter. Requires REDIS_HOST.
+	DISTRIBUTED_RATE_LIMIT_ENABLED = "DISTRIBUTED_RATE_LIMIT_ENABLED"
+	RATE_LIMIT_CHEAP               = "RATE_LIMIT_CHEAP"
+	RATE_LIMIT_CHEAP_WINDOW        = "RATE_LIMIT_CHEAP_WINDOW_SECONDS"
+	RATE_LIMIT_STANDARD            = "RATE_LIMIT_STANDARD"
+	RATE_LIMIT_STANDARD_WINDOW     = "RATE_LIMIT_STANDARD_WINDOW_SECONDS"
 )
 
 // Value constants
 const (
 	ServiceName = "catalog-api"
+
+	ErrorCacheUnavailable     = "cache_unavailable"
+	ErrorRateLimitUnavailable = "rate_limit_unavailable"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/sweetrpg/catalog-api
 go 1.26.5
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/getsentry/sentry-go v0.48.0
 	github.com/gin-contrib/cache v1.4.4
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
+	github.com/gomodule/redigo v1.9.3
 	github.com/google/jsonapi v1.0.0
 	github.com/grafana/pyroscope-go v1.4.1
 	github.com/joho/godotenv v1.5.1
@@ -57,7 +59,6 @@ require (
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
-	github.com/gomodule/redigo v1.9.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.11 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
@@ -88,6 +89,7 @@ require (
 	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zerodha/logf v0.5.5 // indirect
 	go.jtlabs.io/query v1.6.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
@@ -271,6 +273,8 @@ github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gi
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zerodha/logf v0.5.5 h1:AhxHlixHNYwhFjvlgTv6uO4VBKYKxx2I6SbHoHtWLBk=

--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -20,8 +20,18 @@ data:
   PYROSCOPE_SERVER_ADDRESS: http://pyroscope.observability.svc.cluster.local:4040
   PYROSCOPE_TENANT_ID: psw
   SENTRY_RELEASE: "1"
-  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
+  # redis-master is the service name the infrastructure/catalog Helm chart actually creates
+  # (bitnami/redis convention) - "redis" alone has never resolved, which is part of why this
+  # was never exercised end-to-end. See openspec/changes/catalog-api-caching-rate-limiting.
+  REDIS_HOST: redis-master.sweetrpg-catalog.svc.cluster.local
   REDIS_PORT: "6379"
+  CACHE_TTLS: "licenses=30m,volumes=30m,systems=2h,publishers=2h,studios=2h,persons=1h,contributions=1h,reviews=15m"
+  CACHE_DEFAULT_TTL: 1h
+  DISTRIBUTED_RATE_LIMIT_ENABLED: "false"
+  RATE_LIMIT_CHEAP: "120"
+  RATE_LIMIT_CHEAP_WINDOW_SECONDS: "60"
+  RATE_LIMIT_STANDARD: "30"
+  RATE_LIMIT_STANDARD_WINDOW_SECONDS: "60"
   INGRESS_BASE_PATH: /0
   INGRESS_HOST: api.catalog.dev.sweetrpg.com
   INGRESS_SCHEMES: http,https

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -42,7 +42,7 @@ func (l *Limiter) Allow(ctx context.Context, clientKey, tierName string) (bool, 
 	if err != nil {
 		return false, fmt.Errorf("ratelimit: get redis connection: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	key := fmt.Sprintf("ratelimit:%s:%s", tierName, clientKey)
 	count, err := redis.Int(conn.Do("INCR", key))
@@ -64,7 +64,7 @@ func Ping(ctx context.Context, pool *redis.Pool) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, err = conn.Do("PING")
 	return err

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,71 @@
+// Package ratelimit implements a Redis-backed, per-client, per-route-tier request rate
+// limiter. Counters live in Redis (INCR + EXPIRE) rather than per-pod memory, so the limit is
+// consistent across catalog-api's replicas instead of being N times looser depending on how
+// many pods happen to be up.
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// Tier describes a rate-limit budget: at most Limit requests per Window.
+type Tier struct {
+	Limit  int
+	Window int // seconds
+}
+
+// Limiter enforces per-client request limits per tier, backed by a Redis connection pool.
+type Limiter struct {
+	pool  *redis.Pool
+	tiers map[string]Tier
+}
+
+// New builds a Limiter using the given Redis pool and tier definitions. Callers should pass at
+// least a "standard" and "cheap" tier; Allow falls back to "standard" for an unknown tier name.
+func New(pool *redis.Pool, tiers map[string]Tier) *Limiter {
+	return &Limiter{pool: pool, tiers: tiers}
+}
+
+// Allow increments the request counter for clientKey within the named tier and reports whether
+// the request is within that tier's limit. A non-nil error means the Redis backend was
+// unreachable - callers must treat that as fail-closed (reject the request), not fail-open.
+func (l *Limiter) Allow(ctx context.Context, clientKey, tierName string) (bool, error) {
+	tier, ok := l.tiers[tierName]
+	if !ok {
+		tier = l.tiers["standard"]
+	}
+
+	conn, err := l.pool.GetContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("ratelimit: get redis connection: %w", err)
+	}
+	defer conn.Close()
+
+	key := fmt.Sprintf("ratelimit:%s:%s", tierName, clientKey)
+	count, err := redis.Int(conn.Do("INCR", key))
+	if err != nil {
+		return false, fmt.Errorf("ratelimit: incr: %w", err)
+	}
+	if count == 1 {
+		if _, err := conn.Do("EXPIRE", key, tier.Window); err != nil {
+			return false, fmt.Errorf("ratelimit: expire: %w", err)
+		}
+	}
+
+	return count <= tier.Limit, nil
+}
+
+// Ping verifies the Redis backend is reachable, for use in startup/readiness checks.
+func Ping(ctx context.Context, pool *redis.Pool) error {
+	conn, err := pool.GetContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Do("PING")
+	return err
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,154 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gomodule/redigo/redis"
+)
+
+func newTestPool(t *testing.T) (*redis.Pool, *miniredis.Miniredis) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", mr.Addr())
+		},
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	return pool, mr
+}
+
+func TestAllowWithinLimit(t *testing.T) {
+	pool, _ := newTestPool(t)
+	limiter := New(pool, map[string]Tier{"standard": {Limit: 3, Window: 60}})
+
+	for i := 0; i < 3; i++ {
+		allowed, err := limiter.Allow(context.Background(), "client-a", "standard")
+		if err != nil {
+			t.Fatalf("Allow() error = %v", err)
+		}
+		if !allowed {
+			t.Fatalf("Allow() request %d = false, want true (within limit)", i+1)
+		}
+	}
+}
+
+func TestAllowRejectsOverLimit(t *testing.T) {
+	pool, _ := newTestPool(t)
+	limiter := New(pool, map[string]Tier{"standard": {Limit: 2, Window: 60}})
+
+	for i := 0; i < 2; i++ {
+		if allowed, err := limiter.Allow(context.Background(), "client-a", "standard"); err != nil || !allowed {
+			t.Fatalf("Allow() request %d = (%v, %v), want (true, nil)", i+1, allowed, err)
+		}
+	}
+
+	allowed, err := limiter.Allow(context.Background(), "client-a", "standard")
+	if err != nil {
+		t.Fatalf("Allow() error = %v", err)
+	}
+	if allowed {
+		t.Fatal("Allow() over limit = true, want false")
+	}
+}
+
+func TestAllowTracksClientsIndependently(t *testing.T) {
+	pool, _ := newTestPool(t)
+	limiter := New(pool, map[string]Tier{"standard": {Limit: 1, Window: 60}})
+
+	if allowed, err := limiter.Allow(context.Background(), "client-a", "standard"); err != nil || !allowed {
+		t.Fatalf("Allow(client-a) = (%v, %v), want (true, nil)", allowed, err)
+	}
+	if allowed, err := limiter.Allow(context.Background(), "client-b", "standard"); err != nil || !allowed {
+		t.Fatalf("Allow(client-b) = (%v, %v), want (true, nil) - separate client budget", allowed, err)
+	}
+	if allowed, _ := limiter.Allow(context.Background(), "client-a", "standard"); allowed {
+		t.Fatal("Allow(client-a) second request = true, want false - client-a is over its own limit")
+	}
+}
+
+func TestAllowTracksTiersIndependently(t *testing.T) {
+	pool, _ := newTestPool(t)
+	limiter := New(pool, map[string]Tier{
+		"cheap":    {Limit: 5, Window: 60},
+		"standard": {Limit: 1, Window: 60},
+	})
+
+	if allowed, err := limiter.Allow(context.Background(), "client-a", "standard"); err != nil || !allowed {
+		t.Fatalf("Allow(standard) = (%v, %v), want (true, nil)", allowed, err)
+	}
+	if allowed, _ := limiter.Allow(context.Background(), "client-a", "standard"); allowed {
+		t.Fatal("Allow(standard) second request = true, want false")
+	}
+	if allowed, err := limiter.Allow(context.Background(), "client-a", "cheap"); err != nil || !allowed {
+		t.Fatalf("Allow(cheap) = (%v, %v), want (true, nil) - cheap tier has its own budget", allowed, err)
+	}
+}
+
+func TestAllowUnknownTierFallsBackToStandard(t *testing.T) {
+	pool, _ := newTestPool(t)
+	limiter := New(pool, map[string]Tier{"standard": {Limit: 1, Window: 60}})
+
+	if allowed, err := limiter.Allow(context.Background(), "client-a", "unknown-tier"); err != nil || !allowed {
+		t.Fatalf("Allow(unknown-tier) = (%v, %v), want (true, nil) via standard fallback", allowed, err)
+	}
+	if allowed, _ := limiter.Allow(context.Background(), "client-a", "unknown-tier"); allowed {
+		t.Fatal("Allow(unknown-tier) second request = true, want false - fell back to standard's limit of 1")
+	}
+}
+
+func TestAllowFailsClosedWhenBackendUnreachable(t *testing.T) {
+	mr := miniredis.RunT(t)
+	addr := mr.Addr()
+	mr.Close()
+
+	// A fresh pool pointed at the now-closed address, rather than reusing a pool with an
+	// already-established (now half-open) connection - otherwise the OS may not surface the
+	// closed remote end until a long TCP timeout instead of an immediate connection refusal.
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", addr, redis.DialConnectTimeout(2*time.Second))
+		},
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	limiter := New(pool, map[string]Tier{"standard": {Limit: 10, Window: 60}})
+
+	allowed, err := limiter.Allow(context.Background(), "client-a", "standard")
+	if err == nil {
+		t.Fatal("Allow() with unreachable backend error = nil, want non-nil")
+	}
+	if allowed {
+		t.Fatal("Allow() with unreachable backend = true, want false (fail closed)")
+	}
+}
+
+func TestPingSucceedsWhenReachable(t *testing.T) {
+	pool, _ := newTestPool(t)
+
+	if err := Ping(context.Background(), pool); err != nil {
+		t.Fatalf("Ping() error = %v, want nil", err)
+	}
+}
+
+func TestPingFailsWhenUnreachable(t *testing.T) {
+	mr := miniredis.RunT(t)
+	addr := mr.Addr()
+	mr.Close()
+
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", addr, redis.DialConnectTimeout(2*time.Second))
+		},
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	if err := Ping(context.Background(), pool); err == nil {
+		t.Fatal("Ping() with unreachable backend error = nil, want non-nil")
+	}
+}

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -1,0 +1,20 @@
+// Package readiness tracks the reachability of backend dependencies (beyond Mongo, which
+// api-core.go's HealthHandler already covers) so /status/health can fail loud instead of the
+// service silently degrading to an uncached or unlimited mode.
+package readiness
+
+import "sync/atomic"
+
+var cacheReady atomic.Bool
+
+// SetCacheReady records whether the configured cache backend (Redis, when REDIS_HOST is set)
+// is currently reachable. Services without REDIS_HOST configured should call this with true,
+// since the in-memory fallback store has no external dependency to fail.
+func SetCacheReady(ready bool) {
+	cacheReady.Store(ready)
+}
+
+// CacheReady reports the last-known reachability of the configured cache backend.
+func CacheReady() bool {
+	return cacheReady.Load()
+}

--- a/readiness/readiness_test.go
+++ b/readiness/readiness_test.go
@@ -1,0 +1,15 @@
+package readiness
+
+import "testing"
+
+func TestSetCacheReadyRoundTrips(t *testing.T) {
+	SetCacheReady(true)
+	if !CacheReady() {
+		t.Fatal("CacheReady() = false after SetCacheReady(true), want true")
+	}
+
+	SetCacheReady(false)
+	if CacheReady() {
+		t.Fatal("CacheReady() = true after SetCacheReady(false), want false")
+	}
+}

--- a/server/contributions.go
+++ b/server/contributions.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -13,6 +12,7 @@ import (
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	_ "github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -20,11 +20,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupContributionHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupContributionHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up contribution endpoint handlers...")
-	g.GET("/contributions", cache.CachePage(store, time.Hour, listContributions))
-	g.GET("/contributions/:id", cache.CachePage(store, time.Hour, getContribution))
-	// g.GET("/contributions/:id/contributions", cache.CachePage(store, time.Hour, getContributionContributions))
+	ttl := ttls.TTL("contributions")
+	g.GET("/contributions", cache.CachePage(store, ttl, listContributions))
+	g.GET("/contributions/:id", cache.CachePage(store, ttl, getContribution))
+	// g.GET("/contributions/:id/contributions", cache.CachePage(store, ttl, getContributionContributions))
 }
 
 // List contributions.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -3,16 +3,17 @@ package server
 import (
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
+	"github.com/sweetrpg/catalog-api/cachettl"
 )
 
-func SetupHandlers(g *gin.Engine, cache persistence.CacheStore) {
-	setupContributionHandlers(g, cache)
-	setupLicenseHandlers(g, cache)
-	setupPersonHandlers(g, cache)
-	setupPublisherHandlers(g, cache)
-	setupReviewHandlers(g, cache)
-	setupStudioHandlers(g, cache)
-	setupSystemHandlers(g, cache)
-	setupVolumeHandlers(g, cache)
+func SetupHandlers(g *gin.Engine, cache persistence.CacheStore, ttls cachettl.Config) {
+	setupContributionHandlers(g, cache, ttls)
+	setupLicenseHandlers(g, cache, ttls)
+	setupPersonHandlers(g, cache, ttls)
+	setupPublisherHandlers(g, cache, ttls)
+	setupReviewHandlers(g, cache, ttls)
+	setupStudioHandlers(g, cache, ttls)
+	setupSystemHandlers(g, cache, ttls)
+	setupVolumeHandlers(g, cache, ttls)
 	setupStatusHandlers(g)
 }

--- a/server/licenses.go
+++ b/server/licenses.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -19,11 +19,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up license endpoint handlers...")
-	g.GET("/licenses", cache.CachePage(store, time.Hour, listLicenses))
-	g.GET("/licenses/:id", cache.CachePage(store, time.Hour, getLicense))
-	g.GET("/licenses/:id/volumes", cache.CachePage(store, time.Hour, getLicenseVolumes))
+	ttl := ttls.TTL("licenses")
+	g.GET("/licenses", cache.CachePage(store, ttl, listLicenses))
+	g.GET("/licenses/:id", cache.CachePage(store, ttl, getLicense))
+	g.GET("/licenses/:id/volumes", cache.CachePage(store, ttl, getLicenseVolumes))
 }
 
 // List licenses.

--- a/server/persons.go
+++ b/server/persons.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up person endpoint handlers...")
-	g.GET("/persons", cache.CachePage(store, time.Hour, listPersons))
-	g.GET("/persons/:id", cache.CachePage(store, time.Hour, getPerson))
-	// g.GET("/persons/:id/persons", cache.CachePage(store, time.Hour, getPersonPersons))
+	ttl := ttls.TTL("persons")
+	g.GET("/persons", cache.CachePage(store, ttl, listPersons))
+	g.GET("/persons/:id", cache.CachePage(store, ttl, getPerson))
+	// g.GET("/persons/:id/persons", cache.CachePage(store, ttl, getPersonPersons))
 }
 
 // List persons.

--- a/server/publishers.go
+++ b/server/publishers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupPublisherHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupPublisherHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up publisher endpoint handlers...")
-	g.GET("/publishers", cache.CachePage(store, time.Hour, listPublishers))
-	g.GET("/publishers/:id", cache.CachePage(store, time.Hour, getPublisher))
-	// g.GET("/publishers/:id/publishers", cache.CachePage(store, time.Hour, getPublisherPublishers))
+	ttl := ttls.TTL("publishers")
+	g.GET("/publishers", cache.CachePage(store, ttl, listPublishers))
+	g.GET("/publishers/:id", cache.CachePage(store, ttl, getPublisher))
+	// g.GET("/publishers/:id/publishers", cache.CachePage(store, ttl, getPublisherPublishers))
 }
 
 // List publishers.

--- a/server/reviews.go
+++ b/server/reviews.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupReviewHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupReviewHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up review endpoint handlers...")
-	g.GET("/reviews", cache.CachePage(store, time.Hour, listReviews))
-	g.GET("/reviews/:id", cache.CachePage(store, time.Hour, getReview))
-	// g.GET("/reviews/:id/reviews", cache.CachePage(store, time.Hour, getReviewReviews))
+	ttl := ttls.TTL("reviews")
+	g.GET("/reviews", cache.CachePage(store, ttl, listReviews))
+	g.GET("/reviews/:id", cache.CachePage(store, ttl, getReview))
+	// g.GET("/reviews/:id/reviews", cache.CachePage(store, ttl, getReviewReviews))
 }
 
 // List reviews.

--- a/server/status.go
+++ b/server/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	apicores "github.com/sweetrpg/api-core.go/server"
 	_ "github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/common.go/logging"
 )
 
@@ -46,6 +47,15 @@ func healthHandler(c *gin.Context) {
 	// }
 
 	resp := apicores.HealthHandler(c.Request.Context())
+
+	// Fold the cache backend's reachability into the same readiness signal Mongo already
+	// reports, so a configured-but-unreachable Redis surfaces as a failing readiness probe
+	// (Degraded in ArgoCD) instead of a silent cache-miss-only degradation.
+	if !readiness.CacheReady() {
+		resp.Messages = append(resp.Messages, "cache backend unreachable")
+		resp.Errors++
+	}
+
 	status := http.StatusOK
 	if resp.Errors > 0 {
 		status = http.StatusServiceUnavailable

--- a/server/studios.go
+++ b/server/studios.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up studio endpoint handlers...")
-	g.GET("/studios", cache.CachePage(store, time.Hour, listStudios))
-	g.GET("/studios/:id", cache.CachePage(store, time.Hour, getStudio))
-	// g.GET("/studios/:id/studios", cache.CachePage(store, time.Hour, getStudioStudios))
+	ttl := ttls.TTL("studios")
+	g.GET("/studios", cache.CachePage(store, ttl, listStudios))
+	g.GET("/studios/:id", cache.CachePage(store, ttl, getStudio))
+	// g.GET("/studios/:id/studios", cache.CachePage(store, ttl, getStudioStudios))
 }
 
 // List studios.

--- a/server/systems.go
+++ b/server/systems.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupSystemHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupSystemHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up system endpoint handlers...")
-	g.GET("/systems", cache.CachePage(store, time.Hour, listSystems))
-	g.GET("/systems/:id", cache.CachePage(store, time.Hour, getSystem))
-	// g.GET("/systems/:id/systems", cache.CachePage(store, time.Hour, getSystemSystems))
+	ttl := ttls.TTL("systems")
+	g.GET("/systems", cache.CachePage(store, ttl, listSystems))
+	g.GET("/systems/:id", cache.CachePage(store, ttl, getSystem))
+	// g.GET("/systems/:id/systems", cache.CachePage(store, ttl, getSystemSystems))
 }
 
 // List systems.

--- a/server/volumes.go
+++ b/server/volumes.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-contrib/cache"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/jsonapi"
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/otel"
@@ -18,11 +18,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore) {
+func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config) {
 	logging.Logger.Info("Setting up volume endpoint handlers...")
-	g.GET("/volumes", cache.CachePage(store, time.Hour, listVolumes))
-	g.GET("/volumes/:id", cache.CachePage(store, time.Hour, getVolume))
-	// g.GET("/volumes/:id/volumes", cache.CachePage(store, time.Hour, getVolumeVolumes))
+	ttl := ttls.TTL("volumes")
+	g.GET("/volumes", cache.CachePage(store, ttl, listVolumes))
+	g.GET("/volumes/:id", cache.CachePage(store, ttl, getVolume))
+	// g.GET("/volumes/:id/volumes", cache.CachePage(store, ttl, getVolumeVolumes))
 }
 
 // List volumes.


### PR DESCRIPTION
## Summary

catalog-api already wires up per-route response caching (gin-contrib/cache) and a request rate
limiter, but neither works as intended in the dev cluster: the cache is configured to use Redis
(REDIS_HOST is set), but the Redis instance it depends on has never successfully synced, so
every cached request silently degrades. Separately, the rate limiter is a single process-wide
token bucket shared across every client and endpoint.

- Fix the Redis ArgoCD sync and make setupCache() fail loudly if REDIS_HOST is set but unreachable
- Move per-entity cache TTL from a hardcoded time.Hour to a per-route configurable value
- Replace the single global rate limiter with per-client, per-route-group rate limiting

BREAKING: clients relying on the shared limiter's pooled throughput may see lower per-client
limits once limits are enforced per-client.

Closes #143

---
OpenSpec change: `openspec/changes/catalog-api-caching-rate-limiting/proposal.md`