### PR TITLE
fix(kubernetes): point local overlay at the shared local MongoDB

### DIFF
--- a/kubernetes/overlays/local/secrets.yaml
+++ b/kubernetes/overlays/local/secrets.yaml
@@ -18,23 +18,20 @@ spec:
               key: Auth0
 
 ---
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+# Local dev only - points at the shared, no-auth MongoDB in sweetrpg-support
+# (sweetrpg/common-infrastructure's database module) instead of the real Atlas cluster dev/prod
+# use (see that ExternalSecret in kubernetes/overlays/dev/secrets.yaml). This cluster's network
+# can't reliably reach Atlas - confirmed via TCP-level testing while debugging admin-api's
+# failing readiness probe (same shared Atlas cluster).
+apiVersion: v1
+kind: Secret
 
 metadata:
-    name: catalog-api-db
+    name: api-db
 
-spec:
-    refreshInterval: 1h
-    secretStoreRef:
-        name: akeyless
-        kind: ClusterSecretStore
-    target:
-        name: api-db
-        creationPolicy: Owner
-    dataFrom:
-        - extract:
-              key: /sweetrpg/catalog/api/db
+type: Opaque
+stringData:
+    DB_URI: mongodb://mongodb.sweetrpg-support.svc.cluster.local:27017/sweetrpg-catalog
 
 ---
 apiVersion: external-secrets.io/v1


### PR DESCRIPTION
Same fix as admin-api: local overlay was pointing at the real MongoDB Atlas cluster, which this minikube cluster can't reliably reach. Points at the new shared local MongoDB in sweetrpg-support instead.