### PR TITLE
ci(catalog-api): build amd64/arm64 natively in parallel, cache layers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,8 +20,13 @@ permissions:
     packages: write
 
 jobs:
-    docker:
+    meta:
         runs-on: ubuntu-latest
+        outputs:
+            tags: ${{ steps.meta.outputs.tags }}
+            json: ${{ steps.meta.outputs.json }}
+            build-date: ${{ steps.getbuilddate.outputs.isodate }}
+            build-version: ${{ steps.previoustag.outputs.tag }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -37,10 +42,8 @@ jobs:
             - name: Get current date
               id: getbuilddate
               run: |
-                  echo "date=$(date -u)" >> $GITHUB_OUTPUT
                   echo "isodate=$(date -u '+%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
                   echo "tagdate=$(date -u '+%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-                  echo "timestamp=$(date -u '+%s')" >> $GITHUB_OUTPUT
             - name: Docker metadata
               id: meta
               uses: docker/metadata-action@v6
@@ -57,8 +60,31 @@ jobs:
                       type=semver,pattern={{major}}.{{minor}}
                       type=semver,pattern={{major}}
                       type=sha
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v4
+
+    # One native-runner job per platform - no QEMU emulation, and a per-platform GHA cache
+    # scope so the Go build layer only invalidates for the arch that actually changed. Each
+    # leg pushes its own image by digest rather than a tag; `merge` below stitches the digests
+    # into the one multi-arch manifest every tag in `meta` should point at.
+    build:
+        needs: meta
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - platform: linux/amd64
+                      runner: ubuntu-latest
+                    - platform: linux/arm64
+                      runner: ubuntu-24.04-arm
+        runs-on: ${{ matrix.runner }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+              with:
+                fetch-depth: 0
+            - name: Prepare platform pair
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
             - name: Login to registry
@@ -67,27 +93,62 @@ jobs:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Build and push
+            - name: Build and push by digest
               id: docker_build
               uses: docker/build-push-action@v7
               with:
-                  # context: .
-                  push: true
-                  no-cache: true
-                  platforms: linux/amd64,linux/arm64
-                  tags: ${{ steps.meta.outputs.tags }}
+                  platforms: ${{ matrix.platform }}
                   build-args: |
                       BUILD_NUMBER=${{ github.run_number }}
                       BUILD_JOB=${{ github.job }}
                       BUILD_SHA=${{ github.sha }}
-                      BUILD_DATE=${{ steps.getbuilddate.outputs.isodate }}
-                      BUILD_VERSION=${{ steps.previoustag.outputs.tag }}
-            #          tags: registry.sweetrpg.com/sweetrpg-catalog-api:latest
-            # - name: Scan image
-            #   uses: sysdiglabs/scan-action@v1
-            #   with:
-            #     image-tag: registry.sweetrpg.com/sweetrpg-catalog-api:latest
-            #     sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+                      BUILD_DATE=${{ needs.meta.outputs.build-date }}
+                      BUILD_VERSION=${{ needs.meta.outputs.build-version }}
+                  cache-from: type=gha,scope=catalog-api-${{ env.PLATFORM_PAIR }}
+                  cache-to: type=gha,mode=max,scope=catalog-api-${{ env.PLATFORM_PAIR }}
+                  outputs: type=image,name=ghcr.io/sweetrpg/catalog-api,push-by-digest=true,name-canonical=true,push=true
+            - name: Export digest
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.docker_build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
+            - name: Upload digest
+              uses: actions/upload-artifact@v7
+              with:
+                  name: digests-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1
+
+    merge:
+        needs: [meta, build]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v8
+              with:
+                  path: /tmp/digests
+                  pattern: digests-*
+                  merge-multiple: true
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
+            - name: Login to registry
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Create manifest list and push
+              working-directory: /tmp/digests
+              env:
+                  DOCKER_METADATA_OUTPUT_JSON: ${{ needs.meta.outputs.json }}
+              run: |
+                  docker buildx imagetools create \
+                    $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf 'ghcr.io/sweetrpg/catalog-api@sha256:%s ' *)
+            - name: Inspect image
+              run: |
+                  docker buildx imagetools inspect ghcr.io/sweetrpg/catalog-api:${{ needs.meta.outputs.build-version }}
             - name: Create Sentry release
               uses: getsentry/action-release@v3
               env:
@@ -98,10 +159,10 @@ jobs:
                   environment: ${{ vars.SENTRY_ENV }}
 
     update-deployment:
-        needs: docker
+        needs: merge
         if: startsWith(github.ref, 'refs/tags/v')
         uses: sweetrpg/github-actions/.github/workflows/argocd-update-deployment.yaml@master
         with:
             image-name: catalog-api
-            manifest-path: clusters/dev/catalog/services/api.yaml
+            manifest-path: clusters/dev/catalog/api.yaml
         secrets: inherit


### PR DESCRIPTION
## Summary
- Same fix as sweetrpg/catalog-web's docker-build.yml: single-job build emulated arm64 under QEMU on an x86 runner, and `no-cache: true` threw away Docker layer caching entirely.
- Splits into one job per platform on its native runner (`ubuntu-24.04-arm` for arm64 - free GitHub-hosted since this repo is public), each pushing by digest with a per-platform GHA cache scope, then a `merge` job stitches the digests into the multi-arch manifest before creating the Sentry release (moved from the old single job - the image is only genuinely complete after merge).
- Also updates `update-deployment`'s `manifest-path`: `clusters/dev/catalog` was just flattened (`services/` removed) in `sweetrpg/kubernetes`.

## Test plan
- [ ] `workflow_dispatch` from this branch to confirm the split build/merge/push pipeline works before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JH2TSCMFjUbkN8vvwSGmG