### PR TITLE
Point local MongoDB at sweetrpg-db

### DIFF
--- a/kubernetes/overlays/local/secrets.yaml
+++ b/kubernetes/overlays/local/secrets.yaml
@@ -18,7 +18,7 @@ spec:
               key: Auth0
 
 ---
-# Local dev only - points at the shared, no-auth MongoDB in sweetrpg-support
+# Local dev only - points at the shared, no-auth MongoDB in sweetrpg-db
 # (sweetrpg/common-infrastructure's database module) instead of the real Atlas cluster dev/prod
 # use (see that ExternalSecret in kubernetes/overlays/dev/secrets.yaml). This cluster's network
 # can't reliably reach Atlas - confirmed via TCP-level testing while debugging admin-api's
@@ -31,7 +31,7 @@ metadata:
 
 type: Opaque
 stringData:
-    DB_URI: mongodb://mongodb.sweetrpg-support.svc.cluster.local:27017/sweetrpg-catalog
+    DB_URI: mongodb://mongodb.sweetrpg-db.svc.cluster.local:27017/sweetrpg-catalog
 
 ---
 apiVersion: external-secrets.io/v1


### PR DESCRIPTION
## Summary
- sweetrpg-support is retired; the shared local-dev MongoDB now lives in sweetrpg-db

Companion change to sweetrpg/kubernetes and sweetrpg/common-infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)