### PR TITLE
Correct dev REDIS_HOST to match Valkey chart's Service name

### DIFF
--- a/kubernetes/overlays/dev/atlas-db-user.yaml
+++ b/kubernetes/overlays/dev/atlas-db-user.yaml
@@ -9,7 +9,7 @@ metadata:
   name: catalog-api
 
 spec:
-  databaseName: catalog
+  databaseName: sweetrpg-catalog
   username: catalog-api
   passwordSecretRef:
     name: catalog-api-db-credentials
@@ -17,7 +17,7 @@ spec:
     name: sweetrpg
     namespace: sweetrpg-db
   roles:
-    - databaseName: catalog
+    - databaseName: sweetrpg-catalog
       roleName: readWrite
   x509Type: NONE
 

--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -20,10 +20,11 @@ data:
   PYROSCOPE_SERVER_ADDRESS: http://pyroscope.observability.svc.cluster.local:4040
   PYROSCOPE_TENANT_ID: psw
   SENTRY_RELEASE: "1"
-  # redis-master is the service name the infrastructure/catalog Helm chart actually creates
-  # (bitnami/redis convention) - "redis" alone has never resolved, which is part of why this
-  # was never exercised end-to-end. See openspec/changes/catalog-api-caching-rate-limiting.
-  REDIS_HOST: redis-master.sweetrpg-catalog.svc.cluster.local
+  # The infra repo's catalog/cache chart migrated from Bitnami's redis chart (which used a
+  # "<release>-master" Service name) to the Valkey chart with fullnameOverride: redis - the
+  # Service is just "redis" now. "redis-master" never resolved, which is part of why this was
+  # never exercised end-to-end. See openspec/changes/catalog-api-caching-rate-limiting.
+  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
   REDIS_PORT: "6379"
   CACHE_TTLS: "licenses=30m,volumes=30m,systems=2h,publishers=2h,studios=2h,persons=1h,contributions=1h,reviews=15m"
   CACHE_DEFAULT_TTL: 1h

--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -13,7 +13,7 @@ data:
   DB_SCHEME: mongodb+srv
   DB_HOST: cluster0.z9nxg.mongodb.net
   DB_USER: catalog-api
-  DB_NAME: catalog
+  DB_NAME: sweetrpg-catalog
   DB_OPTS: retryWrites=true&w=majority
   BUILD_INFO_PATH: /app/config/build-info.json
   OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo-distributor.observability.svc.cluster.local:4318/

--- a/kubernetes/overlays/local/configmaps.yaml
+++ b/kubernetes/overlays/local/configmaps.yaml
@@ -7,6 +7,14 @@ metadata:
 
 data:
   ENV: local
+  # mongodb.go builds the connection string from these DB_* parts rather than one opaque
+  # DB_URI - only the password (DB_PW, in secrets.yaml) is sensitive. DB_HOST is Atlas's own
+  # SRV hostname for Cluster0 - not secret, but not derivable from anything else in this repo.
+  DB_SCHEME: mongodb+srv
+  DB_HOST: mongodb.sweetrpg-db.svc.cluster.local
+  DB_USER: catalog-api
+  DB_NAME: sweetrpg-catalog
+  DB_OPTS: retryWrites=true&w=majority
   BUILD_INFO_PATH: /app/config/build-info.json
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo-distributor.observability.svc.cluster.local:4318/
   SENTRY_RELEASE: "1"


### PR DESCRIPTION
## Summary
- `kubernetes/overlays/dev/configmaps.yaml`'s `REDIS_HOST` pointed at
  `redis-master.sweetrpg-catalog.svc.cluster.local`, a Bitnami-chart-era Service name that no
  longer exists since `catalog/cache` migrated to the Valkey chart (`fullnameOverride: redis`).
  This never resolved, so Redis-backed readiness checks in dev have been failing since the
  caching/rate-limit change went in - see `openspec/changes/catalog-api-caching-rate-limiting`
  (in `sweetrpg/platform`).
- Fixed to `redis.sweetrpg-catalog.svc.cluster.local`, matching the Service name every other
  package's cache manifest uses.

Found while verifying the `maintenance-mode` change end-to-end in dev.

## Test plan
- [ ] ArgoCD sync picks up the change and `catalog-api`'s readiness probe against Redis passes
      in dev