### PR TITLE
Point atlas-db-password ExternalSecrets at new Akeyless path/key

### DIFF
--- a/kubernetes/overlays/dev/atlas-db-user.yaml
+++ b/kubernetes/overlays/dev/atlas-db-user.yaml
@@ -43,7 +43,12 @@ spec:
   dataFrom:
     # Same Akeyless value this overlay's own secrets.yaml reads (rewritten to DB_PW there) -
     # one password, read by two ExternalSecrets, so the Operator-provisioned Atlas user and the
-    # app's own connection always agree on it. Provisioning: needs a key literally named
-    # "password" at this path (not provisioned by this manifest).
+    # app's own connection always agree on it. Akeyless stores it under the field name
+    # DB_PASSWORD; the Atlas Operator requires the Secret key to be literally "password", hence
+    # the rewrite here.
     - extract:
-        key: /sweetrpg/catalog/api/atlas-db-password
+        key: /sweetrpg/catalog/api/db
+      rewrite:
+        - regexp:
+            source: "DB_PASSWORD"
+            target: "password"

--- a/kubernetes/overlays/dev/secrets.yaml
+++ b/kubernetes/overlays/dev/secrets.yaml
@@ -33,12 +33,12 @@ spec:
         name: api-db
         creationPolicy: Owner
     dataFrom:
-        # Same Akeyless value atlas-db-user.yaml's ExternalSecret reads (unrewritten there,
-        # since the Atlas Operator expects the key name "password") - one password, read by
-        # two ExternalSecrets, so this app and the Atlas-side user the Operator provisions
-        # always agree on it.
+        # Same Akeyless value atlas-db-user.yaml's ExternalSecret reads (rewritten to "password"
+        # there, since the Atlas Operator expects that exact key name) - one password (Akeyless
+        # field DB_PASSWORD), read by two ExternalSecrets, so this app and the Atlas-side user
+        # the Operator provisions always agree on it.
         - extract:
-              key: /sweetrpg/catalog/api/atlas-db-password
+              key: /sweetrpg/catalog/api/db
           rewrite:
               - regexp:
                     source: "(.*)"


### PR DESCRIPTION
## Summary
- Akeyless's `/sweetrpg/catalog/api/atlas-db-password` path was replaced with
  `/sweetrpg/catalog/api/db`, storing the value under a `DB_PASSWORD` field.
- `catalog-api-db-credentials` (read by the Atlas Operator via `AtlasDatabaseUser.passwordSecretRef`,
  which requires the Secret key to be literally `password`) now rewrites `DB_PASSWORD` -> `password`.
- `catalog-api-db` (the app's own DB secret) already rewrote its extracted key to `DB_PW`
  regardless of source field name, so it only needed the path update.

Found while verifying `maintenance-mode` end-to-end in dev - both `ExternalSecret`s were failing
with "could not get secret data from provider" after the Akeyless path moved.

## Test plan
- [ ] `catalog-api-db` and `catalog-api-db-credentials` ExternalSecrets sync Healthy in dev
- [ ] `catalog-api` connects to its Atlas database successfully