### PR TITLE
security: remove startup log dump of the full process environment

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -53,7 +53,6 @@ const redisConnectTimeout = 5 * time.Second
 // @license.url https://mit-license.org/
 func main() {
 	_ = godotenv.Load(".env")
-	log.Printf("ENV: %v", os.Environ())
 
 	logging.Init()
 


### PR DESCRIPTION
## Summary
- \`log.Printf("ENV: %v", os.Environ())\` in \`main()\` printed every secret in the container's
  environment in plaintext on every pod start - \`AUTH0_CLIENT_SECRET\`, \`REDIS_PASS\`, \`DB_PW\`,
  \`HEALTH_TOKEN\`, \`SENTRY_DSN\`, all of it - straight to stdout, unconditionally (not gated by
  log level).
- Found while investigating unrelated Mongo connectivity issues in dev and seeing the full
  plaintext env dump in the pod's logs.

**This should be treated as an active credential exposure** - every secret in this service's
environment has been logged in plaintext on every restart. Recommend rotating
\`AUTH0_CLIENT_SECRET\`, \`REDIS_PASS\`, the Atlas DB password, \`HEALTH_TOKEN\`, and \`SENTRY_DSN\`
for this service once this merges.

## Test plan
- [ ] Confirm no environment dump appears in pod logs after this deploys