### PR TITLE
Target DB_PASSWORD explicitly in the catalog-api-db rewrite

### DIFF
--- a/kubernetes/overlays/dev/secrets.yaml
+++ b/kubernetes/overlays/dev/secrets.yaml
@@ -41,7 +41,7 @@ spec:
               key: /sweetrpg/catalog/api/db
           rewrite:
               - regexp:
-                    source: "(.*)"
+                    source: "DB_PASSWORD"
                     target: DB_PW
 
 ---


### PR DESCRIPTION
## Summary
- \`source: "(.*)"\` in \`catalog-api-db\`'s rewrite matches every field extracted from
  \`/sweetrpg/catalog/api/db\`, not just \`DB_PASSWORD\` - same nondeterministic-collision risk
  fixed in admin-api (sweetrpg/admin-api#27), where it produced a full \`mongodb+srv://\`
  connection string in \`DB_PW\` instead of the bare password. This repo happened not to hit it in
  practice, but the underlying pattern is identical.
- Matches \`catalog-api-db-credentials\`' rewrite (in \`atlas-db-user.yaml\`), which already targets
  \`DB_PASSWORD\` explicitly.

## Test plan
- [ ] \`catalog-api-db\` Secret's \`DB_PW\` key holds just the bare password after this syncs