### PR TITLE
Live-ping the cache backend instead of caching a boot-time readiness result

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -240,16 +240,18 @@ func setupRedisPool() *redis.Pool {
 	}
 }
 
-// setupCache builds the response cache store and, when REDIS_HOST is configured, verifies
-// connectivity before the service reports ready. A configured-but-unreachable Redis fails the
-// readiness probe (see readiness.CacheReady, consumed by /status/health) instead of silently
-// falling back to uncached behavior.
+// setupCache builds the response cache store and, when REDIS_HOST is configured, registers the
+// Redis pool with readiness so /status/health live-pings it on every call (see
+// readiness.CacheReady) instead of trusting a boot-time snapshot - a Redis outage that resolves
+// on its own then lets readiness recover without a pod restart. Also does one startup ping
+// purely to log early if Redis is unreachable at boot; that ping no longer determines
+// readiness by itself.
 func setupCache(redisPool *redis.Pool) persistence.CacheStore {
 	logging.Logger.Info("Setting up query cache...")
 
 	redisHost, found := os.LookupEnv(apiconstants.REDIS_HOST)
 	if !found {
-		readiness.SetCacheReady(true)
+		readiness.SetCachePool(nil)
 		return persistence.NewInMemoryStore(time.Hour)
 	}
 
@@ -257,14 +259,13 @@ func setupCache(redisPool *redis.Pool) persistence.CacheStore {
 	redisPass := os.Getenv(apiconstants.REDIS_PASS)
 	cache := persistence.NewRedisCache(fmt.Sprintf("%s:%s", redisHost, redisPort), redisPass, time.Hour)
 
+	readiness.SetCachePool(redisPool)
+
 	ctx, cancel := context.WithTimeout(context.Background(), redisConnectTimeout)
 	defer cancel()
 	if err := ratelimit.Ping(ctx, redisPool); err != nil {
-		logging.Logger.Error("REDIS_HOST is configured but unreachable; failing readiness instead of silently serving uncached responses",
+		logging.Logger.Error("REDIS_HOST is configured but unreachable at startup; readiness will keep live-checking on each /status/health call",
 			"redis_host", redisHost, "error", err.Error())
-		readiness.SetCacheReady(false)
-	} else {
-		readiness.SetCacheReady(true)
 	}
 
 	return cache

--- a/cmd/catalog-api/main_test.go
+++ b/cmd/catalog-api/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestSetupCacheReportsReadyWhenRedisReachable(t *testing.T) {
 
 	setupCache(pool)
 
-	if !readiness.CacheReady() {
+	if !readiness.CacheReady(context.Background()) {
 		t.Fatal("readiness.CacheReady() = false, want true when Redis is reachable")
 	}
 }
@@ -43,7 +44,7 @@ func TestSetupCacheFailsReadinessWhenRedisUnreachable(t *testing.T) {
 
 	setupCache(pool)
 
-	if readiness.CacheReady() {
+	if readiness.CacheReady(context.Background()) {
 		t.Fatal("readiness.CacheReady() = true, want false when REDIS_HOST is configured but unreachable")
 	}
 }
@@ -60,7 +61,7 @@ func TestSetupCacheReportsReadyWhenRedisNotConfigured(t *testing.T) {
 
 	setupCache(nil)
 
-	if !readiness.CacheReady() {
+	if !readiness.CacheReady(context.Background()) {
 		t.Fatal("readiness.CacheReady() = false, want true when no cache backend is configured (in-memory store, no dependency to fail)")
 	}
 }

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -3,18 +3,30 @@
 // service silently degrading to an uncached or unlimited mode.
 package readiness
 
-import "sync/atomic"
+import (
+	"context"
+	"sync/atomic"
 
-var cacheReady atomic.Bool
+	"github.com/gomodule/redigo/redis"
+	"github.com/sweetrpg/catalog-api/ratelimit"
+)
 
-// SetCacheReady records whether the configured cache backend (Redis, when REDIS_HOST is set)
-// is currently reachable. Services without REDIS_HOST configured should call this with true,
-// since the in-memory fallback store has no external dependency to fail.
-func SetCacheReady(ready bool) {
-	cacheReady.Store(ready)
+var cachePool atomic.Pointer[redis.Pool]
+
+// SetCachePool records the Redis pool CacheReady live-pings on each call. Pass nil when no
+// cache backend is configured (REDIS_HOST unset) - CacheReady then reports true, since the
+// in-memory fallback store has no external dependency to fail.
+func SetCachePool(pool *redis.Pool) {
+	cachePool.Store(pool)
 }
 
-// CacheReady reports the last-known reachability of the configured cache backend.
-func CacheReady() bool {
-	return cacheReady.Load()
+// CacheReady live-pings the configured cache backend rather than returning a cached boot-time
+// result - a Redis outage that resolves on its own should let readiness recover without
+// requiring a pod restart.
+func CacheReady(ctx context.Context) bool {
+	pool := cachePool.Load()
+	if pool == nil {
+		return true
+	}
+	return ratelimit.Ping(ctx, pool) == nil
 }

--- a/readiness/readiness_test.go
+++ b/readiness/readiness_test.go
@@ -1,15 +1,36 @@
 package readiness
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-func TestSetCacheReadyRoundTrips(t *testing.T) {
-	SetCacheReady(true)
-	if !CacheReady() {
-		t.Fatal("CacheReady() = false after SetCacheReady(true), want true")
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gomodule/redigo/redis"
+)
+
+func TestCacheReadyWithNoPoolConfigured(t *testing.T) {
+	SetCachePool(nil)
+	if !CacheReady(context.Background()) {
+		t.Fatal("CacheReady() = false with no pool configured, want true")
+	}
+}
+
+func TestCacheReadyLivePingsRatherThanCaching(t *testing.T) {
+	s := miniredis.RunT(t)
+	addr := s.Addr()
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) { return redis.Dial("tcp", addr) },
+	}
+	SetCachePool(pool)
+	defer SetCachePool(nil)
+
+	if !CacheReady(context.Background()) {
+		t.Fatal("CacheReady() = false with a reachable pool, want true")
 	}
 
-	SetCacheReady(false)
-	if CacheReady() {
-		t.Fatal("CacheReady() = true after SetCacheReady(false), want false")
+	s.Close()
+
+	if CacheReady(context.Background()) {
+		t.Fatal("CacheReady() = true after the backend closed, want false - check should be live, not cached")
 	}
 }

--- a/server/status.go
+++ b/server/status.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	apicores "github.com/sweetrpg/api-core.go/server"
@@ -9,6 +11,10 @@ import (
 	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/common.go/logging"
 )
+
+// cacheReadyTimeout bounds the live Redis ping in healthHandler, matching api-core.go's
+// healthCheckTimeout for the equivalent Mongo checks.
+const cacheReadyTimeout = 5 * time.Second
 
 func setupStatusHandlers(g *gin.Engine) {
 	logging.Logger.Info("Setting up status endpoint handlers...")
@@ -50,8 +56,12 @@ func healthHandler(c *gin.Context) {
 
 	// Fold the cache backend's reachability into the same readiness signal Mongo already
 	// reports, so a configured-but-unreachable Redis surfaces as a failing readiness probe
-	// (Degraded in ArgoCD) instead of a silent cache-miss-only degradation.
-	if !readiness.CacheReady() {
+	// (Degraded in ArgoCD) instead of a silent cache-miss-only degradation. Live-pinged on
+	// every call rather than trusting a boot-time snapshot, so a Redis outage that resolves
+	// lets readiness recover without a pod restart.
+	cacheCtx, cacheCancel := context.WithTimeout(c.Request.Context(), cacheReadyTimeout)
+	defer cacheCancel()
+	if !readiness.CacheReady(cacheCtx) {
 		resp.Messages = append(resp.Messages, "cache backend unreachable")
 		resp.Errors++
 	}


### PR DESCRIPTION
## Summary
\`readiness.CacheReady()\` returned a static flag set once by \`setupCache()\` at startup and never
touched again. A Redis outage at exactly the wrong moment during boot latched readiness to
\`false\` for the pod's entire lifetime - the health check looked live but wasn't, and the only
recovery was a pod restart even after Redis came back healthy.

Traced via a Grafana trace showing both Mongo spans (\`list-collections\`, \`ping-database\`)
succeeding fast with no error while the overall \`/status/health\` span still returned 503 - the
failure was coming from the cache check, not Mongo, and nothing was re-verifying it.

\`readiness.CacheReady\` now takes a \`context.Context\` and live-pings the registered Redis pool on
every call, matching the pattern \`api-core.go\`'s \`HealthHandler\` already uses for Mongo.
\`setupCache\` still does one startup ping, but only to log early visibility - it no longer
determines readiness by itself.

## Test plan
- [x] \`go test ./readiness/... ./cmd/... ./server/...\` passes, including a new test asserting
      \`CacheReady\` reflects the backend closing mid-run rather than a cached earlier result
- [ ] Confirm \`/status/health\` recovers to 200 on its own once Redis is healthy again, without a
      pod restart