### PR TITLE
Run the cache readiness check concurrently, not after Mongo

### DIFF
--- a/server/status.go
+++ b/server/status.go
@@ -52,6 +52,16 @@ func healthHandler(c *gin.Context) {
 	// 	return
 	// }
 
+	// Run the cache check concurrently with api-core.go's Mongo checks rather than after them -
+	// the k8s readinessProbe here has its own 10s timeout, matching api-core.go's Mongo budget
+	// alone; stacking the cache ping on top sequentially could push total handler time past
+	// that window and fail the probe on latency even when every individual check would have
+	// succeeded.
+	cacheCtx, cacheCancel := context.WithTimeout(c.Request.Context(), cacheReadyTimeout)
+	defer cacheCancel()
+	cacheReadyCh := make(chan bool, 1)
+	go func() { cacheReadyCh <- readiness.CacheReady(cacheCtx) }()
+
 	resp := apicores.HealthHandler(c.Request.Context())
 
 	// Fold the cache backend's reachability into the same readiness signal Mongo already
@@ -59,9 +69,7 @@ func healthHandler(c *gin.Context) {
 	// (Degraded in ArgoCD) instead of a silent cache-miss-only degradation. Live-pinged on
 	// every call rather than trusting a boot-time snapshot, so a Redis outage that resolves
 	// lets readiness recover without a pod restart.
-	cacheCtx, cacheCancel := context.WithTimeout(c.Request.Context(), cacheReadyTimeout)
-	defer cacheCancel()
-	if !readiness.CacheReady(cacheCtx) {
+	if !<-cacheReadyCh {
 		resp.Messages = append(resp.Messages, "cache backend unreachable")
 		resp.Errors++
 	}


### PR DESCRIPTION
## Summary
\`healthHandler\` ran \`readiness.CacheReady()\` sequentially after \`apicores.HealthHandler\`'s two
Mongo checks (5s timeout each, up to 10s on their own), stacking up to another 5s on top - worst
case ~15s total. The readinessProbe has its own \`timeoutSeconds: 10\`, so a slow-but-successful
set of checks could still fail the probe purely on latency, independent of the eventual response.

Confirmed in dev: fresh pods on v0.6.4 sat in \`ProgressDeadlineExceeded\` despite Mongo/Redis both
being reachable - this is what caused it, introduced by #160.

Runs the cache ping in a goroutine alongside the Mongo checks instead, so worst-case total time
is \`max(mongo, cache)\` rather than their sum.

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./readiness/... ./cmd/... ./server/...\` all pass
- [ ] Fresh pod on the next release reaches Ready within the probe's timeout