### PR TITLE
Widen readinessProbe timeout margin above Mongo's worst case

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -79,7 +79,15 @@ spec:
                             - name: Authorization
                               value: $(HEALTH_TOKEN)
                         initialDelaySeconds: 30
-                        timeoutSeconds: 10
+                        # api-core.go's HealthHandler budgets up to 5s each for its two Mongo
+                        # checks (list-collections, ping-database) - 10s worst case with zero
+                        # margin against this probe's own timeout. When Mongo ran close to that
+                        # ceiling, kubelet's probe timeout fired first and closed the connection
+                        # mid-check, canceling the request context and surfacing as "context
+                        # canceled" rather than a clean per-check timeout - indistinguishable
+                        # from a real Mongo outage without reading a raw trace. 20s leaves
+                        # headroom above the worst case instead of exactly matching it.
+                        timeoutSeconds: 20
                   volumeMounts:
                       - mountPath: /data
                         name: data


### PR DESCRIPTION
## Summary
\`api-core.go\`'s \`HealthHandler\` budgets up to 5s each for its two Mongo checks
(\`list-collections\`, \`ping-database\`) - 10s worst case, exactly matching this probe's own
\`timeoutSeconds\` with zero margin. When Mongo ran close to that ceiling, kubelet's own probe
timeout fired first and closed the connection mid-check, canceling the request context -
surfacing as \`"context canceled"\` in the response body, indistinguishable from a real Mongo
outage without reading a raw trace.

Confirmed via a captured trace: both Mongo spans succeeded cleanly in one request, but a request
hitting the ceiling failed with context-canceled errors and \`total connections: 0\` - the
canceled connection never got returned to the pool, so it never warmed up, making the next
request just as likely to hit the same ceiling again.

\`timeoutSeconds: 10 -> 20\` leaves real headroom instead of exactly matching the worst case.

## Test plan
- [ ] Fresh pod reaches Ready reliably even when an individual Mongo check runs close to 5s