### PR TITLE
fix(kubernetes): version-prefixed Ingress paths with a latest-alias Service

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 
   - deployment.yaml
   - service.yaml
+  - service-latest.yaml

--- a/kubernetes/base/service-latest.yaml
+++ b/kubernetes/base/service-latest.yaml
@@ -1,0 +1,24 @@
+---
+kind: Service
+apiVersion: v1
+
+metadata:
+  name: api-v0
+
+spec:
+    # Alias for "latest" - the public Ingress's /api/catalog/0 path and any in-cluster caller
+    # that wants latest-not-pinned should target this Service rather than api-v1 directly. Its
+    # selector currently matches the same pods as api-v1 (the only version that exists yet); when
+    # a v2 ships, repoint this selector's `version` at v2 while api-v1 keeps selecting v1 pods
+    # unchanged, so callers pinned to /1 or api-v1 don't move underneath them.
+    selector:
+        app: api
+        version: v1
+        platform: sweetrpg
+        package: catalog
+        component: api
+    type: ClusterIP
+    ports:
+        - name: http
+          port: 8000
+          targetPort: http

--- a/kubernetes/overlays/dev/ingress.yaml
+++ b/kubernetes/overlays/dev/ingress.yaml
@@ -16,8 +16,17 @@ spec:
     - host: dev.sweetrpg.com
       http:
         paths:
+          # /0 always points at the latest version (currently v1); /1 is the pinned v1 route.
+          # Frontends should call /0 unless they need a specific version.
           - pathType: Prefix
-            path: /api/catalog
+            path: /api/0/catalog
+            backend:
+              service:
+                name: api-v0
+                port:
+                  name: http
+          - pathType: Prefix
+            path: /api/1/catalog
             backend:
               service:
                 name: api-v1

--- a/kubernetes/overlays/dev/middlewares.yaml
+++ b/kubernetes/overlays/dev/middlewares.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   stripPrefix:
     prefixes:
-      - /api/catalog/0
-      - /api/catalog/1
+      - /api/0/catalog
+      - /api/1/catalog

--- a/kubernetes/overlays/local/ingress.yaml
+++ b/kubernetes/overlays/local/ingress.yaml
@@ -15,8 +15,17 @@ spec:
     - host: sweetrpg.local
       http:
         paths:
+          # /0 always points at the latest version (currently v1); /1 is the pinned v1 route.
+          # Frontends should call /0 unless they need a specific version.
           - pathType: Prefix
-            path: /api/catalog
+            path: /api/0/catalog
+            backend:
+              service:
+                name: api-v0
+                port:
+                  name: http
+          - pathType: Prefix
+            path: /api/1/catalog
             backend:
               service:
                 name: api-v1

--- a/kubernetes/overlays/local/middlewares.yaml
+++ b/kubernetes/overlays/local/middlewares.yaml
@@ -6,11 +6,7 @@ metadata:
   name: strip-prefix-v1
 
 spec:
-  # Unlike the dev overlay's strip-prefix-v1 (which only strips the bare /0 or /1 version
-  # segment, since dev gives this service its own host with no other path prefix), this overlay
-  # shares one host across every app - strip the full /api/catalog/0 or /api/catalog/1 prefix so
-  # the app still sees its normal unprefixed routes.
   stripPrefix:
     prefixes:
-      - /api/catalog/0
-      - /api/catalog/1
+      - /api/0/catalog
+      - /api/1/catalog


### PR DESCRIPTION
## Summary
- Ingress paths were unversioned (`/api/catalog`) but the strip-prefix middleware only matched `/api/catalog/0` or `/api/catalog/1` - neither ever matched, so requests forwarded to the pod with the path still attached and 404'd.
- Adds `/api/0/catalog` and `/api/1/catalog` path rules (version segment first, matching `shelf-api`'s existing convention) with a matching middleware update.
- Adds a new `api-v0` Service (`kubernetes/base/service-latest.yaml`) as the "latest" alias, routed to by `/0`; `/1` keeps routing to the existing pinned `api-v1` Service.

## Test plan
- [ ] Confirm `https://dev.sweetrpg.com/api/0/catalog/status/ping` and `/api/1/catalog/status/ping` both return 200 once deployed.