### PR TITLE
Authenticate AtlasDatabaseUser against admin database

### DIFF
--- a/kubernetes/overlays/dev/atlas-db-user.yaml
+++ b/kubernetes/overlays/dev/atlas-db-user.yaml
@@ -9,7 +9,7 @@ metadata:
   name: catalog-api
 
 spec:
-  databaseName: sweetrpg-catalog
+  databaseName: admin
   username: catalog-api
   passwordSecretRef:
     name: catalog-api-db-credentials


### PR DESCRIPTION
## Summary
- `spec.databaseName` (the authentication database) was set to `sweetrpg-catalog` instead of `admin`. Atlas requires SCRAM-SHA users to authenticate against `admin` and rejects user creation/reconciliation otherwise with `DATABASE_NAME_INVALID_ADMIN` - confirmed via the Atlas Operator's reconcile error for this exact resource.
- The role's own `databaseName` (already `sweetrpg-catalog`) is what actually scopes data access and is unaffected.

## Test plan
- [ ] Confirm the Atlas Operator reconciles the AtlasDatabaseUser without error
- [ ] Confirm `catalog-api` continues to query its own collections after reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)