### PR TITLE
Rewrite volume PATCH/accept/reject against the version model

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/catalog-api/server"
 	"github.com/sweetrpg/catalog-api/vocabularies"
+	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/common.go/logging"
 	"github.com/sweetrpg/common.go/util"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -102,6 +103,9 @@ func main() {
 	}
 	if err := vocabularies.EnsureIndexes(context.Background()); err != nil {
 		logging.Logger.Error("Error while ensuring vocabularies indexes", "error", err.Error())
+	}
+	if err := data.EnsureVolumeVersioningIndexes(context.Background()); err != nil {
+		logging.Logger.Error("Error while ensuring volume versioning indexes", "error", err.Error())
 	}
 	if err := vocabularies.Backfill(context.Background()); err != nil {
 		logging.Logger.Error("Error while backfilling vocabularies", "error", err.Error())

--- a/cmd/migrate-volumes/main.go
+++ b/cmd/migrate-volumes/main.go
@@ -1,0 +1,111 @@
+// Command migrate-volumes is the one-time cutover for catalog-entity-versioning's volume
+// meta+version data model (see openspec's design.md Migration Plan). It backfills every
+// existing "volumes" document into a meta record + a single live version, then converts every
+// still-pending proposed_changes entry for a volume into a submitted version so no in-flight
+// submitter proposal is silently dropped at cutover.
+//
+// Safe to re-run: MigrateVolumes skips any record that already has a meta record, and each
+// proposal is only converted once per run (re-running after a partial failure will create
+// duplicate submitted versions for proposals already converted in an earlier run - this command
+// doesn't yet mark a proposal as migrated, since proposed_changes is superseded entirely once
+// every entity type's migration completes, see tasks.md task group 8).
+//
+// Known limitation: a pending proposal's staged cover/sample assets (StagedCoverAssetId/
+// StagedSampleAssetIds) aren't representable on a VolumeVersion yet - see tasks.md 3.7. Any
+// text fields (title/description/notes) on such a proposal are still migrated; the staged asset
+// reference itself is logged as skipped and needs manual follow-up.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/sweetrpg/catalog-api/proposedchanges"
+	"github.com/sweetrpg/catalog-data.go/data"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/database"
+)
+
+func main() {
+	_ = godotenv.Load(".env")
+	logging.Init()
+	database.SetupDatabase()
+	defer database.TeardownDatabase()
+
+	ctx := context.Background()
+
+	migratedRecords, err := data.MigrateVolumes(ctx)
+	if err != nil {
+		logging.Logger.Error("migrate-volumes: backfill meta+version records failed", "error", err)
+		os.Exit(1)
+	}
+	fmt.Printf("migrated %d volume record(s) into meta+version\n", migratedRecords)
+
+	migratedProposals, skippedStagedAssets, err := migratePendingProposals(ctx)
+	if err != nil {
+		logging.Logger.Error("migrate-volumes: backfill pending proposals failed", "error", err)
+		os.Exit(1)
+	}
+	fmt.Printf("migrated %d pending proposal(s) into submitted versions\n", migratedProposals)
+	if skippedStagedAssets > 0 {
+		fmt.Printf(
+			"WARNING: %d proposal(s) referenced staged cover/sample assets that were NOT migrated - "+
+				"needs manual follow-up, see this command's doc comment\n", skippedStagedAssets)
+	}
+}
+
+// migratePendingProposals converts every still-pending "volume" proposed_changes entry into a
+// submitted version, applying the proposal's diffed string fields onto the live record's
+// current snapshot as the submitted version's base.
+func migratePendingProposals(ctx context.Context) (migrated, skippedStagedAssets int, err error) {
+	pending, err := proposedchanges.ListPendingByType(ctx, "volume")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, p := range pending {
+		existing, err := data.GetVolume(ctx, p.RecordID)
+		if err != nil {
+			return migrated, skippedStagedAssets, err
+		}
+		if existing == nil {
+			logging.Logger.Warn(
+				"migrate-volumes: skipping proposal for a volume that no longer exists",
+				"proposalId", p.ID.Hex(), "volumeId", p.RecordID)
+			continue
+		}
+
+		updated := *existing
+		for field, change := range p.Diff {
+			newValue, ok := change.New.(string)
+			if !ok {
+				continue
+			}
+			switch field {
+			case "title":
+				updated.Title = newValue
+			case "description":
+				updated.Description = newValue
+			case "notes":
+				updated.Notes = newValue
+			}
+		}
+
+		if _, err := data.CreateSubmittedVolumeVersion(
+			ctx, p.RecordID, &updated, p.SubmittedBy, p.SubmittedAt); err != nil {
+			return migrated, skippedStagedAssets, err
+		}
+		migrated++
+
+		if p.StagedCoverAssetId != "" || len(p.StagedSampleAssetIds) > 0 {
+			logging.Logger.Warn(
+				"migrate-volumes: proposal referenced staged assets - not migrated onto the submitted version",
+				"proposalId", p.ID.Hex(), "volumeId", p.RecordID)
+			skippedStagedAssets++
+		}
+	}
+
+	return migrated, skippedStagedAssets, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -137,3 +137,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/sweetrpg/catalog-objects.go => ../../foundational/catalog-objects/go
+replace github.com/sweetrpg/catalog-data.go => ../../foundational/catalog-data

--- a/proposedchanges/store.go
+++ b/proposedchanges/store.go
@@ -67,6 +67,23 @@ func ListPending(ctx context.Context, recordType, recordID string) ([]*ProposedC
 	return results, nil
 }
 
+// ListPendingByType returns every pending proposed change across all records of one type,
+// oldest first - used by the version-model migration (cmd/migrate-volumes) to find every
+// still-pending proposal that needs to become a submitted version, not just one record's.
+func ListPendingByType(ctx context.Context, recordType string) ([]*ProposedChange, error) {
+	filter := bson.D{
+		{Key: "record_type", Value: recordType},
+		{Key: "status", Value: StatusPending},
+	}
+	sort := bson.D{{Key: "submitted_at", Value: 1}}
+
+	results, err := database.Query[ProposedChange](CollectionName, filter, sort, nil, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("proposedchanges: list pending by type: %w", err)
+	}
+	return results, nil
+}
+
 // Update persists changes to an existing proposed change (its Diff field statuses, derived
 // Status, and review metadata).
 func Update(ctx context.Context, p *ProposedChange) error {

--- a/server/volumes.go
+++ b/server/volumes.go
@@ -27,6 +27,8 @@ func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	ttl := ttls.TTL("volumes")
 	g.GET("/volumes", cache.CachePage(store, ttl, listVolumes))
 	g.GET("/volumes/:id", cache.CachePage(store, ttl, getVolume))
+	g.GET("/volumes/:id/versions", listVolumeVersions)
+	g.GET("/volumes/:id/versions/:version", getVolumeVersion)
 	// g.GET("/volumes/:id/volumes", cache.CachePage(store, ttl, getVolumeVolumes))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
@@ -47,6 +49,12 @@ func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.POST("/volumes/:id/proposed-changes/:proposalId/pull-back", writeRoles, func(c *gin.Context) {
 		pullBackVolumeProposedChange(c, editSessions)
 	})
+
+	g.POST("/volumes/:id/versions/:version/accept", reviewRoles, acceptVolumeVersion)
+	g.POST("/volumes/:id/versions/:version/reject", reviewRoles, rejectVolumeVersion)
+
+	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)
+	g.POST("/volumes/:id/versions/:version/current", rollbackRoles, setCurrentVolumeVersion)
 }
 
 // List volumes.

--- a/server/volumes_finalize.go
+++ b/server/volumes_finalize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sweetrpg/catalog-api/proposedchanges"
 	"github.com/sweetrpg/catalog-api/submissioncap"
 	"github.com/sweetrpg/catalog-data.go/data"
+	"github.com/sweetrpg/catalog-objects.go/models"
 )
 
 // recordTypeVolume is the edit-session recordType this endpoint reads (see docs/
@@ -99,7 +100,7 @@ func finalizeVolumeSession(c *gin.Context, assetsClient *assets.Client, editSess
 			req.SampleAssetIds = &liveSampleIds
 		}
 
-		if !applyVolumePatch(c, existing, req) {
+		if !applyVolumePatch(c, existing, req, models.VersionStateLive) {
 			return
 		}
 		if err := editSessions.Delete(c.Request.Context(), userID, recordTypeVolume); err != nil {

--- a/server/volumes_patch.go
+++ b/server/volumes_patch.go
@@ -11,8 +11,8 @@ import (
 	"github.com/sweetrpg/catalog-api/authz"
 	"github.com/sweetrpg/catalog-api/proposedchanges"
 	"github.com/sweetrpg/catalog-data.go/data"
+	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
-	"github.com/sweetrpg/common.go/logging"
 	modelcore "github.com/sweetrpg/model-core.go/vo"
 )
 
@@ -35,17 +35,11 @@ type creditRequest struct {
 const maxSampleAssetIds = 5
 
 // patchVolumeRequest's fields are pointers so an absent field (nil) is distinguishable from an
-// explicit empty string/omitted array - only present fields are part of the edit/proposal.
+// explicit empty string/omitted array - only present fields are part of the edit/submission.
 //
-// Properties/PublisherIDs/StudioIDs/Credits are editor/admin-only for now (see
-// applyVolumePatch) - the submitter proposal path's FieldChange.New is applied back via a
-// `.(string)` type assertion (volumes_review.go), which can't represent these shapes yet. A
-// submitter request touching any of them is rejected with a clear error rather than silently
-// dropping the field - extending the proposal review path to handle non-string field types is
-// tracked separately, not done here.
-//
-// Format is editor/admin-only permanently, not as a stopgap - per volume-format-selector's
-// spec, a submitter session can't set it at all, directly or via proposal.
+// Properties/PublisherIDs/StudioIDs/Credits/Format/CoverAssetId/SampleAssetIds are editor/admin
+// -only by policy (see hasEditorOnlyFields) - a submitter request touching any of them is
+// rejected with a clear error rather than silently dropping the field.
 type patchVolumeRequest struct {
 	Title          *string            `json:"title"`
 	Description    *string            `json:"description"`
@@ -59,30 +53,42 @@ type patchVolumeRequest struct {
 	SampleAssetIds *[]string          `json:"sampleAssetIds"`
 }
 
-// hasEditorOnlyFields reports whether req touches a field the submitter-proposal path can't yet
-// represent, or that's permanently editor/admin-only (see patchVolumeRequest's doc comment).
+// hasEditorOnlyFields reports whether req touches a field that's editor/admin-only by policy
+// (see patchVolumeRequest's doc comment).
 func (req patchVolumeRequest) hasEditorOnlyFields() bool {
 	return req.Properties != nil || req.PublisherIDs != nil || req.StudioIDs != nil ||
 		req.Credits != nil || req.Format != nil || req.CoverAssetId != nil || req.SampleAssetIds != nil
 }
 
+// pendingProposalResponse is returned by the proposed_changes-based submission paths that are
+// still in use (finalizeVolumeSession's submitter branch, and the generic entity_patch.go
+// mechanism for publisher/studio/person/license) - not the version-based patchVolume path below,
+// which returns submittedVersionResponse instead.
 type pendingProposalResponse struct {
 	ProposalID string `json:"proposalId"`
 	Status     string `json:"status"`
 	Message    string `json:"message"`
 }
 
-// Edit a volume, or propose an edit for review.
+// submittedVersionResponse is returned when a submitter's PATCH creates a submitted version
+// rather than editing the live record.
+type submittedVersionResponse struct {
+	Version int    `json:"version"`
+	State   string `json:"state"`
+	Message string `json:"message"`
+}
+
+// Edit a volume, or submit an edit for review.
 //
 //	@Summary		Edit a volume
-//	@Description	admin/editor roles apply the change to the live record; submitter-only roles create a proposed change for review instead.
+//	@Description	admin/editor roles create a new version that goes live immediately; submitter-only roles create a submitted version for review instead.
 //	@Tags			volumes
 //	@Accept			json
 //	@Produce		json
 //	@Param			id		path		string				true	"Volume ID"
 //	@Param			request	body		patchVolumeRequest	true	"Fields to change"
 //	@Success		200		{object}	interface{}
-//	@Success		202		{object}	pendingProposalResponse
+//	@Success		202		{object}	submittedVersionResponse
 //	@Failure		400		{object}	apiv.ErrorVO
 //	@Failure		404		{object}	apiv.ErrorVO
 //	@Failure		500		{object}	apiv.ErrorVO
@@ -115,26 +121,23 @@ func patchVolume(c *gin.Context) {
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
-	for field, change := range diff {
-		change.Old = fieldValue(existing, field)
-		diff[field] = change
-	}
 
 	roles := authz.Roles(c)
-	if authz.HasRole(roles, authz.RoleAdmin) || authz.HasRole(roles, authz.RoleEditor) {
-		applyVolumePatch(c, existing, req)
-		return
-	}
+	isEditor := authz.HasRole(roles, authz.RoleAdmin) || authz.HasRole(roles, authz.RoleEditor)
 
-	if req.hasEditorOnlyFields() {
+	if !isEditor && req.hasEditorOnlyFields() {
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{
 			Error:   "unsupported_field",
-			Message: "properties, publisherIds, and studioIds can't be proposed yet - an editor or admin must make this change directly",
+			Message: "properties, publisherIds, studioIds, credits, format, coverAssetId, and sampleAssetIds can't be submitted - an editor or admin must make this change directly",
 		})
 		return
 	}
 
-	proposeVolumeChange(c, id, diff)
+	state := catalogmodels.VersionStateSubmitted
+	if isEditor {
+		state = catalogmodels.VersionStateLive
+	}
+	applyVolumePatch(c, existing, req, state)
 }
 
 // patchRequestDiff builds the initial diff map from the request's present fields, with New set
@@ -167,24 +170,14 @@ func fieldValue(v *vo.VolumeVO, field string) string {
 	}
 }
 
-// setFieldValue writes value into one of v's patchable fields.
-func setFieldValue(v *vo.VolumeVO, field, value string) {
-	switch field {
-	case "title":
-		v.Title = value
-	case "description":
-		v.Description = value
-	case "notes":
-		v.Notes = value
-	}
-}
-
-// applyVolumePatch merges req's present fields into existing and writes the result directly to
-// the live record - the admin/editor direct-edit path. Returns whether the update succeeded (an
-// HTTP response, success or failure, has always already been written either way) - callers that
-// have follow-up cleanup contingent on success (finalizeVolumeSession deleting the now-applied
+// applyVolumePatch merges req's present fields into existing and creates a new version with the
+// given state - state VersionStateLive is the admin/editor direct-edit path (the new version
+// goes live immediately); VersionStateSubmitted is the submitter path (a new version is created
+// for review, the live record is untouched). Returns whether the update succeeded (an HTTP
+// response, success or failure, has always already been written either way) - callers that have
+// follow-up cleanup contingent on success (finalizeVolumeSession deleting the now-applied
 // session) need to know which happened.
-func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequest) bool {
+func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequest, state catalogmodels.VersionState) bool {
 	updated := *existing
 	if req.Title != nil {
 		updated.Title = *req.Title
@@ -242,14 +235,30 @@ func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequ
 		}
 	}
 
-	result, err := data.UpdateVolume(c.Request.Context(), existing.ID, &updated)
+	version, err := data.UpdateVolume(c.Request.Context(), existing.ID, &updated, state)
 	if err != nil {
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "update_failed", Message: err.Error()})
 		return false
 	}
-	if result == nil {
+	if version == nil {
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
+		return false
+	}
+
+	if state != catalogmodels.VersionStateLive {
+		c.JSON(http.StatusAccepted, submittedVersionResponse{
+			Version: version.Version,
+			State:   string(version.State),
+			Message: "Change submitted for review",
+		})
+		return true
+	}
+
+	result, err := data.GetVolume(c.Request.Context(), existing.ID)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return false
 	}
 
@@ -305,29 +314,4 @@ func applyCreditsDiff(c *gin.Context, volumeID string, desired []creditRequest, 
 		}
 	}
 	return nil
-}
-
-// proposeVolumeChange stores diff as a pending proposed change rather than touching the live
-// record - the submitter-only path.
-func proposeVolumeChange(c *gin.Context, volumeID string, diff map[string]proposedchanges.FieldChange) {
-	proposal := &proposedchanges.ProposedChange{
-		RecordType:  "volume",
-		RecordID:    volumeID,
-		Diff:        diff,
-		SubmittedBy: authz.Subject(c),
-	}
-
-	id, err := proposedchanges.Add(c.Request.Context(), proposal)
-	if err != nil {
-		logging.Logger.Error("Error while storing proposed volume change", "error", err.Error())
-		sentry.CaptureException(err)
-		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "propose_failed", Message: err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusAccepted, pendingProposalResponse{
-		ProposalID: id,
-		Status:     proposedchanges.StatusPending,
-		Message:    "Change proposed for review",
-	})
 }

--- a/server/volumes_review.go
+++ b/server/volumes_review.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sweetrpg/catalog-api/editsession"
 	"github.com/sweetrpg/catalog-api/proposedchanges"
 	"github.com/sweetrpg/catalog-data.go/data"
+	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/common.go/logging"
 )
 
@@ -124,7 +125,14 @@ func acceptVolumeProposedChange(c *gin.Context, assetsClient *assets.Client) {
 		}
 
 		newValue, _ := change.New.(string)
-		setFieldValue(&updated, field, newValue)
+		switch field {
+		case "title":
+			updated.Title = newValue
+		case "description":
+			updated.Description = newValue
+		case "notes":
+			updated.Notes = newValue
+		}
 		change.Status = proposedchanges.StatusAccepted
 		proposal.Diff[field] = change
 		applied = append(applied, field)
@@ -157,7 +165,7 @@ func acceptVolumeProposedChange(c *gin.Context, assetsClient *assets.Client) {
 
 	if appliedAny {
 		updated.UpdatedBy = authz.Subject(c)
-		if _, err := data.UpdateVolume(c.Request.Context(), volumeID, &updated); err != nil {
+		if _, err := data.UpdateVolume(c.Request.Context(), volumeID, &updated, models.VersionStateLive); err != nil {
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "update_failed", Message: err.Error()})
 			return

--- a/server/volumes_submission_management_test.go
+++ b/server/volumes_submission_management_test.go
@@ -103,7 +103,14 @@ func TestOnlyAdminCanSetSubmissionCap(t *testing.T) {
 func TestRetractChangesStatusWithoutAffectingLiveRecord(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	deps := newTestDeps(t, []string{authz.RoleSubmitter})
-	doPatch(t, deps.Router, "/volumes/"+seed.ID, map[string]string{"title": "Proposed Title"})
+	seedEditSession(t, deps, "auth0|test-reviewer", "volume", editsession.Session{
+		RecordID: seed.ID,
+		Fields:   map[string]any{"title": "Proposed Title"},
+	})
+	finalize := doPost(t, deps.Router, "/volumes/"+seed.ID+"/finalize-session", nil)
+	if finalize.Code != http.StatusAccepted {
+		t.Fatalf("finalize status = %d, want %d, body: %s", finalize.Code, http.StatusAccepted, finalize.Body.String())
+	}
 
 	pending, err := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
 	if err != nil || len(pending) == 0 {
@@ -127,7 +134,14 @@ func TestRetractChangesStatusWithoutAffectingLiveRecord(t *testing.T) {
 func TestPullBackCreatesSessionAndRetractsSource(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	deps := newTestDeps(t, []string{authz.RoleSubmitter})
-	doPatch(t, deps.Router, "/volumes/"+seed.ID, map[string]string{"title": "Proposed Title"})
+	seedEditSession(t, deps, "auth0|test-reviewer", "volume", editsession.Session{
+		RecordID: seed.ID,
+		Fields:   map[string]any{"title": "Proposed Title"},
+	})
+	finalize := doPost(t, deps.Router, "/volumes/"+seed.ID+"/finalize-session", nil)
+	if finalize.Code != http.StatusAccepted {
+		t.Fatalf("finalize status = %d, want %d, body: %s", finalize.Code, http.StatusAccepted, finalize.Body.String())
+	}
 
 	pending, err := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
 	if err != nil || len(pending) == 0 {
@@ -167,7 +181,14 @@ func TestPullBackConflictsWithExistingSession(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	other := seedVolume(t, "Other Volume")
 	deps := newTestDeps(t, []string{authz.RoleSubmitter})
-	doPatch(t, deps.Router, "/volumes/"+seed.ID, map[string]string{"title": "Proposed Title"})
+	seedEditSession(t, deps, "auth0|test-reviewer", "volume", editsession.Session{
+		RecordID: seed.ID,
+		Fields:   map[string]any{"title": "Proposed Title"},
+	})
+	finalize := doPost(t, deps.Router, "/volumes/"+seed.ID+"/finalize-session", nil)
+	if finalize.Code != http.StatusAccepted {
+		t.Fatalf("finalize status = %d, want %d, body: %s", finalize.Code, http.StatusAccepted, finalize.Body.String())
+	}
 
 	pending, err := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
 	if err != nil || len(pending) == 0 {

--- a/server/volumes_versions.go
+++ b/server/volumes_versions.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gin-gonic/gin"
+	apiv "github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-api/authz"
+	"github.com/sweetrpg/catalog-data.go/data"
+)
+
+// acceptVersionRequest mirrors acceptProposalRequest for the version-based accept action.
+type acceptVersionRequest struct {
+	// Fields lists which changed field names to accept; the rest are left unaccepted. Nil (the
+	// key omitted entirely) means accept every changed field.
+	Fields *[]string `json:"fields"`
+}
+
+type rejectVersionRequest struct {
+	Note string `json:"note"`
+}
+
+type reviewVersionResponse struct {
+	Version   int      `json:"version"`
+	State     string   `json:"state"`
+	Conflicts []string `json:"conflicts,omitempty"`
+}
+
+// versionParam parses the :version path parameter, writing a 400 response and returning ok=false
+// if it isn't a positive integer.
+func versionParam(c *gin.Context) (int, bool) {
+	version, err := strconv.Atoi(c.Param("version"))
+	if err != nil || version < 1 {
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: "version must be a positive integer"})
+		return 0, false
+	}
+	return version, true
+}
+
+// List a volume's version history.
+//
+//	@Summary		List a volume's versions
+//	@Description	Every version for this volume, newest first.
+//	@Tags			volumes
+//	@Produce		json
+//	@Param			id	path		string	true	"Volume ID"
+//	@Success		200	{array}		vo.VolumeVersionVO
+//	@Failure		500	{object}	apiv.ErrorVO
+//	@Router			/volumes/{id}/versions [get]
+func listVolumeVersions(c *gin.Context) {
+	id := c.Param("id")
+
+	versions, err := data.ListVolumeVersions(c.Request.Context(), id)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, versions)
+}
+
+// Get one version of a volume.
+//
+//	@Summary		Get a volume version
+//	@Description	One version's full field snapshot, regardless of whether it's current.
+//	@Tags			volumes
+//	@Produce		json
+//	@Param			id		path		string	true	"Volume ID"
+//	@Param			version	path		int		true	"Version number"
+//	@Success		200		{object}	vo.VolumeVersionVO
+//	@Failure		400		{object}	apiv.ErrorVO
+//	@Failure		404		{object}	apiv.ErrorVO
+//	@Failure		500		{object}	apiv.ErrorVO
+//	@Router			/volumes/{id}/versions/{version} [get]
+func getVolumeVersion(c *gin.Context) {
+	id := c.Param("id")
+	version, ok := versionParam(c)
+	if !ok {
+		return
+	}
+
+	result, err := data.GetVolumeVersion(c.Request.Context(), id, version)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+	if result == nil {
+		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Accept a submitted version, in full or in part.
+//
+//	@Summary		Accept a submitted volume version
+//	@Description	editor/admin only. Omit "fields" to accept every changed field.
+//	@Tags			volumes
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Volume ID"
+//	@Param			version	path		int						true	"Submitted version number"
+//	@Param			request	body		acceptVersionRequest	false	"Fields to accept"
+//	@Success		200		{object}	reviewVersionResponse
+//	@Failure		400		{object}	apiv.ErrorVO
+//	@Failure		404		{object}	apiv.ErrorVO
+//	@Failure		500		{object}	apiv.ErrorVO
+//	@Router			/volumes/{id}/versions/{version}/accept [post]
+func acceptVolumeVersion(c *gin.Context) {
+	id := c.Param("id")
+	version, ok := versionParam(c)
+	if !ok {
+		return
+	}
+
+	var req acceptVersionRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
+		return
+	}
+
+	var selectedFields []string
+	if req.Fields != nil {
+		selectedFields = *req.Fields
+	}
+
+	accepted, conflicts, err := data.AcceptVolumeVersion(c.Request.Context(), id, version, selectedFields, authz.Subject(c), nil)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "accept_failed", Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, reviewVersionResponse{
+		Version:   accepted.Version,
+		State:     string(accepted.State),
+		Conflicts: conflicts,
+	})
+}
+
+// Reject a submitted version in full.
+//
+//	@Summary		Reject a submitted volume version
+//	@Description	editor/admin only.
+//	@Tags			volumes
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Volume ID"
+//	@Param			version	path		int						true	"Submitted version number"
+//	@Param			request	body		rejectVersionRequest	false	"Optional review note"
+//	@Success		200		{object}	reviewVersionResponse
+//	@Failure		400		{object}	apiv.ErrorVO
+//	@Failure		404		{object}	apiv.ErrorVO
+//	@Failure		500		{object}	apiv.ErrorVO
+//	@Router			/volumes/{id}/versions/{version}/reject [post]
+func rejectVolumeVersion(c *gin.Context) {
+	id := c.Param("id")
+	version, ok := versionParam(c)
+	if !ok {
+		return
+	}
+
+	var req rejectVersionRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
+		return
+	}
+
+	var note *string
+	if req.Note != "" {
+		note = &req.Note
+	}
+
+	if err := data.RejectVolumeVersion(c.Request.Context(), id, version, authz.Subject(c), note); err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "reject_failed", Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, reviewVersionResponse{Version: version, State: "rejected"})
+}
+
+// Roll a volume back (or forward) to an arbitrary existing version.
+//
+//	@Summary		Set a volume's current version
+//	@Description	admin only. Marks the given version live and archives whichever version was previously current.
+//	@Tags			volumes
+//	@Produce		json
+//	@Param			id		path		string	true	"Volume ID"
+//	@Param			version	path		int		true	"Version number to make current"
+//	@Success		200		{object}	vo.VolumeVersionVO
+//	@Failure		400		{object}	apiv.ErrorVO
+//	@Failure		404		{object}	apiv.ErrorVO
+//	@Failure		500		{object}	apiv.ErrorVO
+//	@Router			/volumes/{id}/versions/{version}/current [post]
+func setCurrentVolumeVersion(c *gin.Context) {
+	id := c.Param("id")
+	version, ok := versionParam(c)
+	if !ok {
+		return
+	}
+
+	result, err := data.SetCurrentVolumeVersion(c.Request.Context(), id, version)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "rollback_failed", Message: err.Error()})
+		return
+	}
+	if result == nil {
+		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/server/volumes_write_test.go
+++ b/server/volumes_write_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -420,13 +421,20 @@ func TestPatchVolumeSubmitterCannotSetEditorOnlyFields(t *testing.T) {
 	}
 }
 
-func TestPatchVolumeSubmitterCreatesProposalWithoutTouchingLiveRecord(t *testing.T) {
+func TestPatchVolumeSubmitterCreatesSubmittedVersionWithoutTouchingLiveRecord(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	r := newTestRouter(t, []string{authz.RoleSubmitter})
 
 	rec := doPatch(t, r, "/volumes/"+seed.ID, map[string]string{"title": "Proposed By Submitter"})
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	var resp submittedVersionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Version != 2 || resp.State != "submitted" {
+		t.Errorf("response = %+v, want version 2, state submitted", resp)
 	}
 
 	got, err := data.GetVolume(t.Context(), seed.ID)
@@ -437,15 +445,15 @@ func TestPatchVolumeSubmitterCreatesProposalWithoutTouchingLiveRecord(t *testing
 		t.Errorf("live Title = %q, want unchanged %q", got.Title, "Original Title")
 	}
 
-	pending, err := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
+	version, err := data.GetVolumeVersion(t.Context(), seed.ID, 2)
 	if err != nil {
-		t.Fatalf("ListPending() error = %v", err)
+		t.Fatalf("GetVolumeVersion() error = %v", err)
 	}
-	if len(pending) != 1 {
-		t.Fatalf("ListPending() returned %d, want 1", len(pending))
+	if version == nil {
+		t.Fatalf("GetVolumeVersion() = nil, want the submitted version")
 	}
-	if pending[0].Diff["title"].New != "Proposed By Submitter" {
-		t.Errorf("proposal title = %v, want %q", pending[0].Diff["title"].New, "Proposed By Submitter")
+	if version.Title != "Proposed By Submitter" {
+		t.Errorf("submitted version title = %q, want %q", version.Title, "Proposed By Submitter")
 	}
 }
 
@@ -459,7 +467,7 @@ func TestPatchVolumeUserRoleForbidden(t *testing.T) {
 	}
 }
 
-func TestListAndAcceptAllProposedChanges(t *testing.T) {
+func TestListAndAcceptAllVersions(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	submitter := newTestRouter(t, []string{authz.RoleSubmitter})
 	doPatch(t, submitter, "/volumes/"+seed.ID, map[string]string{
@@ -468,35 +476,34 @@ func TestListAndAcceptAllProposedChanges(t *testing.T) {
 	})
 
 	editor := newTestRouter(t, []string{authz.RoleEditor})
-	listRec := httptest.NewRequest(http.MethodGet, "/volumes/"+seed.ID+"/proposed-changes", nil)
+	listRec := httptest.NewRequest(http.MethodGet, "/volumes/"+seed.ID+"/versions", nil)
 	listRec.Header.Set("Authorization", "Bearer some-token")
 	rec := httptest.NewRecorder()
 	editor.ServeHTTP(rec, listRec)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	var proposals []proposedchanges.ProposedChange
-	if err := json.Unmarshal(rec.Body.Bytes(), &proposals); err != nil {
+	var versions []vo.VolumeVersionVO
+	if err := json.Unmarshal(rec.Body.Bytes(), &versions); err != nil {
 		t.Fatalf("unmarshal list response: %v", err)
 	}
-	if len(proposals) != 1 {
-		t.Fatalf("listed %d proposals, want 1", len(proposals))
+	if len(versions) != 2 {
+		t.Fatalf("listed %d versions, want 2", len(versions))
 	}
-	proposalID := proposals[0].ID.Hex()
 
-	acceptRec := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/accept", nil)
+	acceptRec := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/accept", seed.ID), nil)
 	if acceptRec.Code != http.StatusOK {
 		t.Fatalf("accept status = %d, want %d, body: %s", acceptRec.Code, http.StatusOK, acceptRec.Body.String())
 	}
-	var acceptResp reviewProposalResponse
+	var acceptResp reviewVersionResponse
 	if err := json.Unmarshal(acceptRec.Body.Bytes(), &acceptResp); err != nil {
 		t.Fatalf("unmarshal accept response: %v", err)
 	}
-	if acceptResp.Status != proposedchanges.StatusAccepted {
-		t.Errorf("Status = %q, want %q", acceptResp.Status, proposedchanges.StatusAccepted)
+	if acceptResp.State != "live" {
+		t.Errorf("State = %q, want %q", acceptResp.State, "live")
 	}
-	if len(acceptResp.Applied) != 2 {
-		t.Errorf("Applied = %v, want 2 fields", acceptResp.Applied)
+	if len(acceptResp.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none", acceptResp.Conflicts)
 	}
 
 	got, err := data.GetVolume(t.Context(), seed.ID)
@@ -508,7 +515,7 @@ func TestListAndAcceptAllProposedChanges(t *testing.T) {
 	}
 }
 
-func TestAcceptSubsetOfFields(t *testing.T) {
+func TestAcceptSubsetOfFieldsDerivesNewVersion(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	submitter := newTestRouter(t, []string{authz.RoleSubmitter})
 	doPatch(t, submitter, "/volumes/"+seed.ID, map[string]string{
@@ -517,19 +524,16 @@ func TestAcceptSubsetOfFields(t *testing.T) {
 	})
 
 	editor := newTestRouter(t, []string{authz.RoleEditor})
-	pending, _ := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
-	proposalID := pending[0].ID.Hex()
-
-	rec := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/accept", map[string][]string{
+	rec := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/accept", seed.ID), map[string][]string{
 		"fields": {"title"},
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	var resp reviewProposalResponse
+	var resp reviewVersionResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-	if resp.Status != proposedchanges.StatusPartiallyAccepted {
-		t.Errorf("Status = %q, want %q", resp.Status, proposedchanges.StatusPartiallyAccepted)
+	if resp.Version != 3 {
+		t.Errorf("Version = %d, want 3 (a derived version)", resp.Version)
 	}
 
 	got, err := data.GetVolume(t.Context(), seed.ID)
@@ -542,18 +546,26 @@ func TestAcceptSubsetOfFields(t *testing.T) {
 	if got.Description != "seed description" {
 		t.Errorf("Description = %q, want unchanged", got.Description)
 	}
+
+	original, err := data.GetVolumeVersion(t.Context(), seed.ID, 2)
+	if err != nil {
+		t.Fatalf("GetVolumeVersion() error = %v", err)
+	}
+	if original.State != "partially_accepted" {
+		t.Errorf("original version state = %q, want %q", original.State, "partially_accepted")
+	}
+	if original.ResultingVersion == nil || *original.ResultingVersion != 3 {
+		t.Errorf("original version ResultingVersion = %v, want pointer to 3", original.ResultingVersion)
+	}
 }
 
-func TestRejectProposedChange(t *testing.T) {
+func TestRejectVolumeVersion(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	submitter := newTestRouter(t, []string{authz.RoleSubmitter})
 	doPatch(t, submitter, "/volumes/"+seed.ID, map[string]string{"title": "Rejected Title"})
 
 	editor := newTestRouter(t, []string{authz.RoleEditor})
-	pending, _ := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
-	proposalID := pending[0].ID.Hex()
-
-	rec := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/reject", map[string]string{
+	rec := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/reject", seed.ID), map[string]string{
 		"note": "not needed",
 	})
 	if rec.Code != http.StatusOK {
@@ -568,35 +580,32 @@ func TestRejectProposedChange(t *testing.T) {
 		t.Errorf("live Title = %q, want unchanged", got.Title)
 	}
 
-	proposal, err := proposedchanges.Get(t.Context(), proposalID)
+	version, err := data.GetVolumeVersion(t.Context(), seed.ID, 2)
 	if err != nil {
-		t.Fatalf("Get() error = %v", err)
+		t.Fatalf("GetVolumeVersion() error = %v", err)
 	}
-	if proposal.Status != proposedchanges.StatusRejected {
-		t.Errorf("Status = %q, want %q", proposal.Status, proposedchanges.StatusRejected)
+	if version.State != "rejected" {
+		t.Errorf("State = %q, want %q", version.State, "rejected")
 	}
-	if proposal.ReviewNote != "not needed" {
-		t.Errorf("ReviewNote = %q, want %q", proposal.ReviewNote, "not needed")
+	if version.ReviewNote == nil || *version.ReviewNote != "not needed" {
+		t.Errorf("ReviewNote = %v, want %q", version.ReviewNote, "not needed")
 	}
 }
 
-func TestReviewingAlreadyReviewedProposalReturns409(t *testing.T) {
+func TestReviewingAlreadyReviewedVersionReturns400(t *testing.T) {
 	seed := seedVolume(t, "Original Title")
 	submitter := newTestRouter(t, []string{authz.RoleSubmitter})
 	doPatch(t, submitter, "/volumes/"+seed.ID, map[string]string{"title": "First"})
 
 	editor := newTestRouter(t, []string{authz.RoleEditor})
-	pending, _ := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
-	proposalID := pending[0].ID.Hex()
-
-	first := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/reject", nil)
+	first := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/reject", seed.ID), nil)
 	if first.Code != http.StatusOK {
 		t.Fatalf("first reject status = %d, want %d", first.Code, http.StatusOK)
 	}
 
-	second := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/accept", nil)
-	if second.Code != http.StatusConflict {
-		t.Fatalf("second review status = %d, want %d", second.Code, http.StatusConflict)
+	second := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/accept", seed.ID), nil)
+	if second.Code != http.StatusBadRequest {
+		t.Fatalf("second review status = %d, want %d", second.Code, http.StatusBadRequest)
 	}
 }
 
@@ -606,18 +615,14 @@ func TestAcceptFlagsConflictWithoutApplyingStaleValue(t *testing.T) {
 	doPatch(t, submitter, "/volumes/"+seed.ID, map[string]string{"title": "Submitter's Title"})
 
 	editor := newTestRouter(t, []string{authz.RoleEditor})
-	// A direct edit lands after the proposal was submitted, changing the live title out from
-	// under it.
+	// A direct edit lands after the submission, changing the live title out from under it.
 	doPatch(t, editor, "/volumes/"+seed.ID, map[string]string{"title": "Editor's Direct Edit"})
 
-	pending, _ := proposedchanges.ListPending(t.Context(), "volume", seed.ID)
-	proposalID := pending[0].ID.Hex()
-
-	rec := doPost(t, editor, "/volumes/"+seed.ID+"/proposed-changes/"+proposalID+"/accept", nil)
+	rec := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/2/accept", seed.ID), nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	var resp reviewProposalResponse
+	var resp reviewVersionResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if len(resp.Conflicts) != 1 || resp.Conflicts[0] != "title" {
 		t.Errorf("Conflicts = %v, want [title]", resp.Conflicts)
@@ -628,6 +633,31 @@ func TestAcceptFlagsConflictWithoutApplyingStaleValue(t *testing.T) {
 		t.Fatalf("GetVolume() error = %v", err)
 	}
 	if got.Title != "Editor's Direct Edit" {
-		t.Errorf("Title = %q, want editor's direct edit to survive, not the stale proposal value", got.Title)
+		t.Errorf("Title = %q, want editor's direct edit to survive, not the stale submission value", got.Title)
+	}
+}
+
+func TestSetCurrentVolumeVersionAdminOnly(t *testing.T) {
+	seed := seedVolume(t, "Original Title")
+	editor := newTestRouter(t, []string{authz.RoleEditor})
+	doPatch(t, editor, "/volumes/"+seed.ID, map[string]string{"title": "V2 Title"})
+
+	forbidden := doPost(t, editor, fmt.Sprintf("/volumes/%s/versions/1/current", seed.ID), nil)
+	if forbidden.Code != http.StatusForbidden {
+		t.Fatalf("editor rollback status = %d, want %d", forbidden.Code, http.StatusForbidden)
+	}
+
+	admin := newTestRouter(t, []string{authz.RoleAdmin})
+	rec := doPost(t, admin, fmt.Sprintf("/volumes/%s/versions/1/current", seed.ID), nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin rollback status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got, err := data.GetVolume(t.Context(), seed.ID)
+	if err != nil {
+		t.Fatalf("GetVolume() error = %v", err)
+	}
+	if got.Title != "Original Title" {
+		t.Errorf("live Title = %q, want rollback to restore %q", got.Title, "Original Title")
 	}
 }


### PR DESCRIPTION
## Summary
Task group 3 of `catalog-entity-versioning`: adds `GET /volumes/:id/versions[/:version]`,
rewrites `PATCH /volumes/:id` to create a version instead of mutating the live record (editor/
admin: live immediately, submitter: submitted), rewrites accept/reject against the version model
(full accept, selected-fields accept producing a derived version, drifted-baseVersion conflict
exclusion), and adds an admin-only rollback endpoint.

**Known scope gap (see tasks.md 3.7)**: `finalizeVolumeSession` (the edit-session entry point
`catalog-web` actually uses for submitter edits, not direct `PATCH`), staged cover/sample asset
promotion, `submissioncap`, `retract`, and `pull-back` are NOT rewired here - they stay on
`proposed_changes`. Submitters now have two parallel paths landing in two places until a
follow-up spec covers staged-vs-promoted assets on `VolumeVersion`. Both the old
`/proposed-changes/:id/accept|reject` and the new `/versions/:version/accept|reject` endpoints
stay live for this reason.

Depends on sweetrpg/catalog-objects.go#56 and sweetrpg/catalog-data.go#29 (temporary `replace`
directives in go.mod until those merge and release).

Part of sweetrpg/platform#39.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` - all pass, including rewritten volume accept/selected-fields/reject/
      rollback/conflict tests and the retract/pull-back tests updated to seed via finalize-session