### PR TITLE
fix(tracing): propagate trace context to auth-api and assets-web

### DIFF
--- a/assets/client.go
+++ b/assets/client.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/textproto"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Client calls assets-web's asset store endpoints.
@@ -25,7 +27,13 @@ type Client struct {
 // service can still start when ASSETS_WEB_URL isn't configured; every call will then fail with
 // a transport error.
 func NewClient(baseURL string) *Client {
-	return &Client{baseURL: baseURL, http: &http.Client{Timeout: 10 * time.Second}}
+	return &Client{
+		baseURL: baseURL,
+		http: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
 }
 
 // NotFoundError means assets-web has no asset at the given kind/id.

--- a/authz/client.go
+++ b/authz/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sweetrpg/common.go/logging"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Platform role names, matching auth-api's fixed role model exactly (see
@@ -52,7 +53,13 @@ type Client struct {
 // service can still start when AUTH_API_URL isn't configured; every Check call will then fail
 // with a transport error, which RequireAnyRole surfaces as a 503.
 func NewClient(baseURL string) *Client {
-	return &Client{baseURL: baseURL, http: &http.Client{Timeout: 5 * time.Second}}
+	return &Client{
+		baseURL: baseURL,
+		http: &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
 }
 
 // Check verifies token against auth-api and returns the caller's allowed/roles/subject for the

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/sweetrpg/mongodb.go v0.0.193
 	go.mongodb.org/mongo-driver v1.17.9
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.70.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/time v0.15.0
@@ -48,6 +49,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/diegoholiveira/jsonlogic/v3 v3.9.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.15 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect


### PR DESCRIPTION
## Summary
Neither authz.Client nor assets.Client set an http.Client Transport, so no trace context was
ever injected on outgoing requests regardless of the global propagator
(sweetrpg/api-core.go#154 fixes that side). Wraps both with otelhttp.NewTransport so the
/authz/check call to auth-api and the asset-store calls to assets-web link into the request's
actual trace instead of auth-api/assets-web starting a disconnected root span.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean