### PR TITLE
fix(deps): bump api-core.go to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
-	github.com/sweetrpg/api-core.go v0.1.0
+	github.com/sweetrpg/api-core.go v0.1.1
 	github.com/sweetrpg/catalog-data.go v0.7.0
 	github.com/sweetrpg/catalog-objects.go v0.4.0
 	github.com/sweetrpg/common.go v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/swaggo/gin-swagger v1.6.1 h1:Ri06G4gc9N4t4k8hekMigJ9zKTFSlqj/9paAQCQs
 github.com/swaggo/gin-swagger v1.6.1/go.mod h1:LQ+hJStHakCWRiK/YNYtJOu4mR2FP+pxLnILT/qNiTw=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
-github.com/sweetrpg/api-core.go v0.1.0 h1:mlRoCVmS/QCO11LU8Fnl82xYJhTvI4IXFMgoH34IiA0=
-github.com/sweetrpg/api-core.go v0.1.0/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
+github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+EYX9w=
+github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
 github.com/sweetrpg/catalog-data.go v0.7.0 h1:IXiiGTOXJ4OQzvmBy4eIaG+S0eTyfQBKo0yXpMDDxlU=
 github.com/sweetrpg/catalog-data.go v0.7.0/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
 github.com/sweetrpg/catalog-objects.go v0.4.0 h1:6BD5IqXcqBXpIfJx13+iX2GeOrIAt83nTemvxyBt0iU=


### PR DESCRIPTION
## Summary
Pulls in sweetrpg/api-core.go#155 - fixes a resource schema URL conflict that panics on every
startup. Production is currently CrashLoopBackOff-ing against v0.1.0.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean