### PR TITLE
Add GET /staged-assets/pending for the reclaim job cross-check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-data.go v0.7.0
+	github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23
 	github.com/sweetrpg/catalog-objects.go v0.4.0
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23
+	github.com/sweetrpg/catalog-data.go v0.8.0
 	github.com/sweetrpg/catalog-objects.go v0.4.0
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/sweetrpg/catalog-data.go v0.7.0 h1:IXiiGTOXJ4OQzvmBy4eIaG+S0eTyfQBKo0
 github.com/sweetrpg/catalog-data.go v0.7.0/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
 github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23 h1:m70m+JJglx0fHrIjJjjGfJnb89Qlyi1Pw2E/hoU1BLY=
 github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
+github.com/sweetrpg/catalog-data.go v0.8.0 h1:UG3F7TqmspguAvfME/T1P1gScajhJ2U/bsHZpPYxu+c=
+github.com/sweetrpg/catalog-data.go v0.8.0/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
 github.com/sweetrpg/catalog-objects.go v0.4.0 h1:6BD5IqXcqBXpIfJx13+iX2GeOrIAt83nTemvxyBt0iU=
 github.com/sweetrpg/catalog-objects.go v0.4.0/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+
 github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
 github.com/sweetrpg/catalog-data.go v0.7.0 h1:IXiiGTOXJ4OQzvmBy4eIaG+S0eTyfQBKo0yXpMDDxlU=
 github.com/sweetrpg/catalog-data.go v0.7.0/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
+github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23 h1:m70m+JJglx0fHrIjJjjGfJnb89Qlyi1Pw2E/hoU1BLY=
+github.com/sweetrpg/catalog-data.go v0.7.1-0.20260818054754-b84dee785d23/go.mod h1:mzbF7v9RFB/uTALcmgXt15JXJ8rq3N1kgjpRW1U9bfo=
 github.com/sweetrpg/catalog-objects.go v0.4.0 h1:6BD5IqXcqBXpIfJx13+iX2GeOrIAt83nTemvxyBt0iU=
 github.com/sweetrpg/catalog-objects.go v0.4.0/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -19,6 +19,7 @@ func SetupHandlers(g *gin.Engine, cache persistence.CacheStore, ttls cachettl.Co
 	setupSystemHandlers(g, cache, ttls, authzClient)
 	setupVolumeHandlers(g, cache, ttls, authzClient, assetsClient, editSessions)
 	setupVocabularyHandlers(g, authzClient)
+	setupStagedAssetHandlers(g)
 	setupSubmissionCapHandlers(g, authzClient)
 	setupStatusHandlers(g)
 }

--- a/server/staged_assets.go
+++ b/server/staged_assets.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gin-gonic/gin"
+	apiv "github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-data.go/data"
+	"github.com/sweetrpg/common.go/logging"
+)
+
+func setupStagedAssetHandlers(g *gin.Engine) {
+	logging.Logger.Info("Setting up staged-asset endpoint handlers...")
+	g.GET("/staged-assets/pending", listPendingStagedAssets)
+}
+
+type pendingStagedAssetsResponse struct {
+	CoverAssetIds  []string `json:"coverAssetIds"`
+	SampleAssetIds []string `json:"sampleAssetIds"`
+}
+
+// List staged asset ids a pending submission still references.
+//
+//	@Summary		List staged asset ids referenced by a pending submission
+//	@Description	Internal, unauthenticated (matches other GET list endpoints) - called by
+//					assets-web's periodic reclaim job so it never deletes a staged cover/sample
+//					still needed by a pending volume version.
+//	@Tags			staged-assets
+//	@Produce		json
+//	@Success		200	{object}	pendingStagedAssetsResponse
+//	@Failure		500	{object}	apiv.ErrorVO
+//	@Router			/staged-assets/pending [get]
+func listPendingStagedAssets(c *gin.Context) {
+	pending, err := data.ListPendingStagedAssetIds(c.Request.Context())
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, pendingStagedAssetsResponse{
+		CoverAssetIds:  pending.CoverAssetIds,
+		SampleAssetIds: pending.SampleAssetIds,
+	})
+}


### PR DESCRIPTION
Part of sweetrpg/platform#38 (durable-volume-editing), task 2.4.

`assets-web`'s periodic reclaim job needs to know which staged cover/sample asset ids a
pending submission still references before deleting an "orphaned"-looking staged file.
Adds an internal, unauthenticated `GET /staged-assets/pending` (same trust model as this
service's other GET list endpoints - internal DNS only, no sensitive data) backed by
catalog-data.go's new `ListPendingStagedAssetIds`.

Depends on sweetrpg/catalog-data.go#37 - not yet released, so go.mod currently pins a
pseudo-version against that PR's branch commit. **Swap for the real tag once that PR
merges and releases**, before this PR merges.