### PR TITLE
fix(cache): invalidate response cache after a successful write

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -94,6 +94,13 @@ func main() {
 	}
 	cache := setupCache(redisPool)
 	ttls := cachettl.Load()
+	// entity_version_patch.go (publishers/studios/persons/licenses) and volumes_patch.go/
+	// volumes_versions.go have no per-route cache invalidation of their own - without this, a
+	// successful write leaves cache.CachePage's cached GET responses stale for up to the
+	// configured TTL (an hour by default), so a save looks like it silently failed until the
+	// TTL expires. See cacheInvalidationMiddleware's own doc comment for why this is a full
+	// Flush() rather than a targeted per-key delete.
+	r.Use(cacheInvalidationMiddleware(cache))
 
 	database.SetupDatabase()
 	defer database.TeardownDatabase()
@@ -391,6 +398,36 @@ func rateLimitClientKey(c *gin.Context) string {
 		return "key:" + apiKey
 	}
 	return "ip:" + c.ClientIP()
+}
+
+// cacheInvalidationMiddleware flushes the response cache after any write (POST/PATCH/PUT/
+// DELETE) that succeeds (2xx status). A full Flush() rather than a targeted per-key delete:
+// gin-contrib/cache's page-cache key is derived from the full request URL (including query
+// string), which every read route (list with filters, single-record GET, sub-resource GETs)
+// would need reconstructing to invalidate precisely - not worth the complexity against this
+// service's write volume, which is low (admin/editor entity edits, not a hot path).
+func cacheInvalidationMiddleware(store persistence.CacheStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		if !isCacheInvalidatingMethod(c.Request.Method) {
+			return
+		}
+		if status := c.Writer.Status(); status < 200 || status >= 300 {
+			return
+		}
+		if err := store.Flush(); err != nil {
+			logging.Logger.Warn("failed to flush response cache after write", "error", err.Error())
+		}
+	}
+}
+
+func isCacheInvalidatingMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 // RateLimiter selects between the new Redis-backed per-client limiter and the legacy

--- a/cmd/catalog-api/main_test.go
+++ b/cmd/catalog-api/main_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-contrib/cache/persistence"
+	"github.com/gin-gonic/gin"
 	apiconstants "github.com/sweetrpg/api-core.go/constants"
 	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/common.go/logging"
@@ -63,5 +68,68 @@ func TestSetupCacheReportsReadyWhenRedisNotConfigured(t *testing.T) {
 
 	if !readiness.CacheReady(context.Background()) {
 		t.Fatal("readiness.CacheReady() = false, want true when no cache backend is configured (in-memory store, no dependency to fail)")
+	}
+}
+
+func TestCacheInvalidationMiddlewareFlushesOnSuccessfulWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := persistence.NewInMemoryStore(time.Minute)
+	if err := store.Set("some-cached-get", "stale value", persistence.DEFAULT); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(cacheInvalidationMiddleware(store))
+	r.PATCH("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPatch, "/publishers/1", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var got string
+	if err := store.Get("some-cached-get", &got); err != persistence.ErrCacheMiss {
+		t.Fatalf("cache entry after a successful write: err = %v, want ErrCacheMiss (flushed)", err)
+	}
+}
+
+func TestCacheInvalidationMiddlewareLeavesCacheOnFailedWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := persistence.NewInMemoryStore(time.Minute)
+	if err := store.Set("some-cached-get", "still fresh", persistence.DEFAULT); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(cacheInvalidationMiddleware(store))
+	r.PATCH("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusInternalServerError) })
+
+	req := httptest.NewRequest(http.MethodPatch, "/publishers/1", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var got string
+	if err := store.Get("some-cached-get", &got); err != nil || got != "still fresh" {
+		t.Fatalf("cache entry after a failed write: got = %q, err = %v, want unchanged", got, err)
+	}
+}
+
+func TestCacheInvalidationMiddlewareLeavesCacheOnRead(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := persistence.NewInMemoryStore(time.Minute)
+	if err := store.Set("some-cached-get", "still fresh", persistence.DEFAULT); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(cacheInvalidationMiddleware(store))
+	r.GET("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/publishers/1", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var got string
+	if err := store.Get("some-cached-get", &got); err != nil || got != "still fresh" {
+		t.Fatalf("cache entry after a GET: got = %q, err = %v, want unchanged", got, err)
 	}
 }


### PR DESCRIPTION
`entity_version_patch.go` (the generic PATCH handler for publishers/studios/persons/licenses)
and `volumes_patch.go`/`volumes_versions.go` have no per-route cache invalidation of their own,
but `GET /<type>/:id` and friends are wrapped in `cache.CachePage` with up to a 1-hour default
TTL. A successful write left every subsequent read serving stale cached data for up to an hour -
reported as "edited a publisher's website, detail page still shows the old value."

Confirmed live: PATCHed a publisher successfully (clean 302 redirect, no error in logs), but the
record still showed the old (empty) website value afterward - consistent with a stale cache
read, not a failed write.

Adds a global middleware that flushes the cache store after any write (POST/PATCH/PUT/DELETE)
that returns 2xx. A full `Flush()` rather than a targeted per-key delete: the page-cache key is
derived from the full request URL including query string, which every read route would need
reconstructing to invalidate precisely - not worth the complexity against this service's write
volume (admin/editor entity edits, not a hot path).

`go build`/`go vet`/`go test ./...` all pass, including 3 new tests for the middleware itself
(flush-on-success, no-flush-on-failure, no-flush-on-read).