### PR TITLE
fix(cache): scope write-invalidation flush to the response cache DB only

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -100,7 +100,7 @@ func main() {
 	// configured TTL (an hour by default), so a save looks like it silently failed until the
 	// TTL expires. See cacheInvalidationMiddleware's own doc comment for why this is a full
 	// Flush() rather than a targeted per-key delete.
-	r.Use(cacheInvalidationMiddleware(cache))
+	r.Use(cacheInvalidationMiddleware(cache, redisPool))
 
 	database.SetupDatabase()
 	defer database.TeardownDatabase()
@@ -401,12 +401,21 @@ func rateLimitClientKey(c *gin.Context) string {
 }
 
 // cacheInvalidationMiddleware flushes the response cache after any write (POST/PATCH/PUT/
-// DELETE) that succeeds (2xx status). A full Flush() rather than a targeted per-key delete:
+// DELETE) that succeeds (2xx status). A full flush rather than a targeted per-key delete:
 // gin-contrib/cache's page-cache key is derived from the full request URL (including query
 // string), which every read route (list with filters, single-record GET, sub-resource GETs)
 // would need reconstructing to invalidate precisely - not worth the complexity against this
 // service's write volume, which is low (admin/editor entity edits, not a hot path).
-func cacheInvalidationMiddleware(store persistence.CacheStore) gin.HandlerFunc {
+//
+// This does NOT call persistence.RedisStore's own Flush() - that issues Redis FLUSHALL, which
+// wipes every logical DB on the server, not just the cache's own (DB 0). This service shares
+// its Redis instance with the edit-session store (DB 2, see setupEditSessionPool) specifically
+// so cache/rate-limit and edit-session data can't collide - a FLUSHALL from here would erase
+// every in-flight edit session on every write, platform-wide. When Redis is configured, this
+// issues FLUSHDB directly against redisPool (which, like the cache, is never SELECTed off DB
+// 0), scoped to only the response cache. When Redis isn't configured (in-memory fallback),
+// store.Flush() is safe - persistence.MemoryStore's Flush() only clears its own local map.
+func cacheInvalidationMiddleware(store persistence.CacheStore, redisPool *redis.Pool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next()
 		if !isCacheInvalidatingMethod(c.Request.Method) {
@@ -415,7 +424,15 @@ func cacheInvalidationMiddleware(store persistence.CacheStore) gin.HandlerFunc {
 		if status := c.Writer.Status(); status < 200 || status >= 300 {
 			return
 		}
-		if err := store.Flush(); err != nil {
+		if redisPool == nil {
+			if err := store.Flush(); err != nil {
+				logging.Logger.Warn("failed to flush response cache after write", "error", err.Error())
+			}
+			return
+		}
+		conn := redisPool.Get()
+		defer func() { _ = conn.Close() }()
+		if _, err := conn.Do("FLUSHDB"); err != nil {
 			logging.Logger.Warn("failed to flush response cache after write", "error", err.Error())
 		}
 	}

--- a/cmd/catalog-api/main_test.go
+++ b/cmd/catalog-api/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
+	"github.com/gomodule/redigo/redis"
 	apiconstants "github.com/sweetrpg/api-core.go/constants"
 	"github.com/sweetrpg/catalog-api/readiness"
 	"github.com/sweetrpg/common.go/logging"
@@ -79,7 +80,7 @@ func TestCacheInvalidationMiddlewareFlushesOnSuccessfulWrite(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.Use(cacheInvalidationMiddleware(store))
+	r.Use(cacheInvalidationMiddleware(store, nil))
 	r.PATCH("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodPatch, "/publishers/1", nil)
@@ -100,7 +101,7 @@ func TestCacheInvalidationMiddlewareLeavesCacheOnFailedWrite(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.Use(cacheInvalidationMiddleware(store))
+	r.Use(cacheInvalidationMiddleware(store, nil))
 	r.PATCH("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusInternalServerError) })
 
 	req := httptest.NewRequest(http.MethodPatch, "/publishers/1", nil)
@@ -113,6 +114,62 @@ func TestCacheInvalidationMiddlewareLeavesCacheOnFailedWrite(t *testing.T) {
 	}
 }
 
+func TestCacheInvalidationMiddlewareFlushesOnlyCacheDBNotEditSessionDB(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mr := miniredis.RunT(t)
+
+	cacheConn, err := redis.Dial("tcp", mr.Addr())
+	if err != nil {
+		t.Fatalf("dialing cache DB: %v", err)
+	}
+	if _, err := cacheConn.Do("SET", "some-cached-get", "stale value"); err != nil {
+		t.Fatalf("seeding cache DB: %v", err)
+	}
+	_ = cacheConn.Close()
+
+	sessionConn, err := redis.Dial("tcp", mr.Addr(), redis.DialDatabase(editSessionRedisDB))
+	if err != nil {
+		t.Fatalf("dialing edit-session DB: %v", err)
+	}
+	if _, err := sessionConn.Do("SET", "edit-session:user:volume", "in-flight edit"); err != nil {
+		t.Fatalf("seeding edit-session DB: %v", err)
+	}
+	_ = sessionConn.Close()
+
+	redisPool := &redis.Pool{
+		Dial: func() (redis.Conn, error) { return redis.Dial("tcp", mr.Addr()) },
+	}
+	defer func() { _ = redisPool.Close() }()
+
+	store := persistence.NewInMemoryStore(time.Minute)
+	r := gin.New()
+	r.Use(cacheInvalidationMiddleware(store, redisPool))
+	r.PATCH("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPatch, "/publishers/1", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	cacheConn, err = redis.Dial("tcp", mr.Addr())
+	if err != nil {
+		t.Fatalf("dialing cache DB: %v", err)
+	}
+	defer func() { _ = cacheConn.Close() }()
+	if exists, err := redis.Int(cacheConn.Do("EXISTS", "some-cached-get")); err != nil || exists != 0 {
+		t.Fatalf("cache DB key after write: exists = %v, err = %v, want gone (flushed)", exists, err)
+	}
+
+	sessionConn, err = redis.Dial("tcp", mr.Addr(), redis.DialDatabase(editSessionRedisDB))
+	if err != nil {
+		t.Fatalf("dialing edit-session DB: %v", err)
+	}
+	defer func() { _ = sessionConn.Close() }()
+	if got, err := redis.String(sessionConn.Do("GET", "edit-session:user:volume")); err != nil || got != "in-flight edit" {
+		t.Fatalf("edit-session DB key after write: got = %q, err = %v, want untouched - a FLUSHALL "+
+			"here would silently delete every in-flight volume edit session platform-wide", got, err)
+	}
+}
+
 func TestCacheInvalidationMiddlewareLeavesCacheOnRead(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	store := persistence.NewInMemoryStore(time.Minute)
@@ -121,7 +178,7 @@ func TestCacheInvalidationMiddlewareLeavesCacheOnRead(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.Use(cacheInvalidationMiddleware(store))
+	r.Use(cacheInvalidationMiddleware(store, nil))
 	r.GET("/publishers/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/publishers/1", nil)


### PR DESCRIPTION
Critical regression from the cache-invalidation-on-write fix (#213, released as v0.15.2):
`cacheInvalidationMiddleware` called `persistence.RedisStore.Flush()`, which issues Redis
`FLUSHALL` - server-wide, wiping every logical DB on the instance, not just the cache's own
(DB 0).

catalog-api shares its Redis instance with the durable edit-session store (DB 2, see
`setupEditSessionPool`) specifically so cache/rate-limit and edit-session data can't collide -
but `FLUSHALL` doesn't respect DB boundaries. Every successful write to catalog-api (including
the contribution-type/property-name vocabulary POSTs fired by catalog-web's 'add a new type'
affordances) was silently deleting every in-flight volume edit session platform-wide.

Confirmed live on dev: a user editing 'Artifacts and Oddities' had their edit session vanish
mid-edit (three consecutive session-autosave calls 404'd, final submit 400'd with 'No in-flight
edit session for this volume') right after a series of vocabulary-add writes in the same window.

## Fix
Issue `FLUSHDB` directly against `redisPool` (DB 0, same as the cache) instead of going
through `store.Flush()`. The in-memory fallback path (no Redis configured) still uses
`store.Flush()` safely - that implementation only clears its own local map.

## Test plan
- [x] New regression test: seeds both DB 0 (cache) and DB 2 (edit-session) via miniredis,
  confirms a write clears DB 0 but leaves DB 2 untouched.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...` (all pass)