### PR TITLE
Add create route, license tags field, and license-volumes association

### DIFF
--- a/server/entity_version_patch.go
+++ b/server/entity_version_patch.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -19,6 +20,15 @@ type entityFieldAccessor[T any] struct {
 	set func(*T, string)
 }
 
+// entityArrayFieldAccessor is entityFieldAccessor's counterpart for a patchable []string field
+// (e.g. license tags) - a separate map rather than widening entityFieldAccessor itself, since
+// every existing field on every entity is a plain string and this keeps that common case
+// untyped-any-free.
+type entityArrayFieldAccessor[T any] struct {
+	get func(*T) []string
+	set func(*T, []string)
+}
+
 // entityVersionAPIConfig wires the generic version-based patch/review/rollback flow below (shared
 // across publisher, studio, person, license, and system - the meta+version model
 // volumes_patch.go/volumes_versions.go implement bespoke for volumes, predating this shared
@@ -28,7 +38,9 @@ type entityFieldAccessor[T any] struct {
 type entityVersionAPIConfig[T any, V any] struct {
 	recordType        string
 	fields            map[string]entityFieldAccessor[T]
+	arrayFields       map[string]entityArrayFieldAccessor[T]
 	get               func(c *gin.Context, id string) (*T, error)
+	create            func(c *gin.Context, entity *T, createdBy string) (*string, error)
 	createVersion     func(c *gin.Context, id string, entity *T, state catalogmodels.VersionState) (*V, error)
 	listVersions      func(c *gin.Context, id string) ([]*V, error)
 	getVersion        func(c *gin.Context, id string, version int) (*V, error)
@@ -40,22 +52,83 @@ type entityVersionAPIConfig[T any, V any] struct {
 	versionNumber     func(*V) int
 }
 
+// createEntityVersion creates a brand-new record, always live - unlike patchEntityVersion, there
+// is no "submitted for review" state for a record that doesn't exist yet to compare a submission
+// against, so every role able to reach this route (writeRoles - admin/editor/submitter, same as
+// patchEntityVersion's own gate) creates the record directly.
+func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var entity T
+		if err := c.ShouldBindJSON(&entity); err != nil {
+			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
+			return
+		}
+
+		id, err := cfg.create(c, &entity, authz.Subject(c))
+		if err != nil {
+			sentry.CaptureException(err)
+			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "create_failed", Message: err.Error()})
+			return
+		}
+		if id == nil {
+			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "create_failed", Message: "no id returned"})
+			return
+		}
+
+		result, err := cfg.get(c, *id)
+		if err != nil {
+			sentry.CaptureException(err)
+			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+			return
+		}
+		c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+		c.Writer.WriteHeader(http.StatusCreated)
+		if err := jsonapi.MarshalPayload(c.Writer, result); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+}
+
 // patchEntityVersion edits an entity, or submits an edit for review, creating a version either
 // way - the version-model counterpart of patchEntity.
 func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 
-		var req map[string]*string
+		// Bound to json.RawMessage rather than *string so a field can be either a string
+		// (cfg.fields) or an array (cfg.arrayFields, e.g. license tags) - each raw value is
+		// unmarshaled against whichever map recognizes its key below.
+		var req map[string]json.RawMessage
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 			return
 		}
+
+		stringValues := make(map[string]string, len(req))
+		arrayValues := make(map[string][]string, len(req))
 		hasKnownField := false
-		for field, value := range req {
-			if _, known := cfg.fields[field]; known && value != nil {
+		for field, raw := range req {
+			if len(raw) == 0 || string(raw) == "null" {
+				continue
+			}
+			if _, known := cfg.fields[field]; known {
+				var s string
+				if err := json.Unmarshal(raw, &s); err != nil {
+					c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: field + ": " + err.Error()})
+					return
+				}
+				stringValues[field] = s
 				hasKnownField = true
-				break
+				continue
+			}
+			if _, known := cfg.arrayFields[field]; known {
+				var a []string
+				if err := json.Unmarshal(raw, &a); err != nil {
+					c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: field + ": " + err.Error()})
+					return
+				}
+				arrayValues[field] = a
+				hasKnownField = true
 			}
 		}
 		if !hasKnownField {
@@ -75,12 +148,11 @@ func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Hand
 		}
 
 		updated := *existing
-		for field, value := range req {
-			accessor, known := cfg.fields[field]
-			if !known || value == nil {
-				continue
-			}
-			accessor.set(&updated, *value)
+		for field, value := range stringValues {
+			cfg.fields[field].set(&updated, value)
+		}
+		for field, value := range arrayValues {
+			cfg.arrayFields[field].set(&updated, value)
 		}
 
 		roles := authz.Roles(c)

--- a/server/license_volumes.go
+++ b/server/license_volumes.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gin-gonic/gin"
+	"github.com/google/jsonapi"
+	apiutil "github.com/sweetrpg/api-core.go/util"
+	apiv "github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/catalog-api/authz"
+	"github.com/sweetrpg/catalog-data.go/data"
+	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+)
+
+type patchLicenseVolumesRequest struct {
+	VolumeIDs []string `json:"volumeIds"`
+}
+
+// fetchLicenseVolumes returns every volume currently referencing a license - mirrors
+// getLicenseVolumes' own query (license_ids $in [id]), factored out here since this handler
+// needs to call it twice (before and after the diff below).
+func fetchLicenseVolumes(c *gin.Context, licenseID string) ([]*vo.VolumeVO, error) {
+	inOp := "$in"
+	params := apiutil.QueryParams{
+		Filter: []apiutil.Filter{{Field: "license_ids", Operation: &inOp, Value: []string{licenseID}}},
+	}
+	return data.QueryVolumes(c.Request.Context(), params)
+}
+
+func fetchLicenseVolumeIDs(c *gin.Context, licenseID string) ([]string, error) {
+	volumes, err := fetchLicenseVolumes(c, licenseID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(volumes))
+	for i, v := range volumes {
+		ids[i] = v.ID
+	}
+	return ids, nil
+}
+
+// patchLicenseVolumes sets the complete list of volumes a license is associated with - full
+// replace semantics, same convention volumes_patch.go's own PublisherIDs/StudioIDs already use.
+// License<->volume association is volume-owned data (vo.VolumeVO.Licenses), not license-owned -
+// getLicenseVolumes/fetchLicenseVolumeIDs above read it via a reverse query for exactly that
+// reason. So this diffs the requested set against the current one and, for each added/removed
+// volume, updates that volume's own Licenses field directly (editor/admin only - this route
+// writes to records other than the one named in the URL, same tier as accept/reject, not open to
+// submitters). Not transactional - matches this codebase's existing multi-entity fetch/update
+// loops (e.g. applyVolumePatch's own Publisher/Studio ID resolution), which don't use Mongo
+// transactions either.
+func patchLicenseVolumes(c *gin.Context) {
+	id := c.Param("id")
+
+	license, err := data.GetLicense(c.Request.Context(), id)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+	if license == nil {
+		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
+		return
+	}
+
+	var req patchLicenseVolumesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
+		return
+	}
+
+	currentIDs, err := fetchLicenseVolumeIDs(c, id)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+
+	current := make(map[string]bool, len(currentIDs))
+	for _, vid := range currentIDs {
+		current[vid] = true
+	}
+	requested := make(map[string]bool, len(req.VolumeIDs))
+	for _, vid := range req.VolumeIDs {
+		requested[vid] = true
+	}
+
+	updatedBy := authz.Subject(c)
+
+	for _, vid := range req.VolumeIDs {
+		if current[vid] {
+			continue
+		}
+		if err := setVolumeHasLicense(c, vid, id, true, updatedBy); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+	for _, vid := range currentIDs {
+		if requested[vid] {
+			continue
+		}
+		if err := setVolumeHasLicense(c, vid, id, false, updatedBy); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+
+	volumes, err := fetchLicenseVolumes(c, id)
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	c.Writer.WriteHeader(http.StatusOK)
+	if err := jsonapi.MarshalPayload(c.Writer, volumes); err != nil {
+		sentry.CaptureException(err)
+	}
+}
+
+// setVolumeHasLicense adds or removes one license ID from a volume's Licenses relation and saves
+// the volume live - a full-record UpdateVolume, since that's the only write path this data layer
+// exposes for volume (matches PublisherIDs/StudioIDs' own "id-only stub is enough, UpdateVolume
+// re-resolves the full relation" convention in applyVolumePatch).
+func setVolumeHasLicense(c *gin.Context, volumeID, licenseID string, add bool, updatedBy string) error {
+	volume, err := data.GetVolume(c.Request.Context(), volumeID)
+	if err != nil {
+		return err
+	}
+	if volume == nil {
+		return nil
+	}
+
+	licenses := make([]*vo.LicenseVO, 0, len(volume.Licenses)+1)
+	found := false
+	for _, l := range volume.Licenses {
+		if l.ID == licenseID {
+			found = true
+			if !add {
+				continue
+			}
+		}
+		licenses = append(licenses, l)
+	}
+	if add && !found {
+		licenses = append(licenses, &vo.LicenseVO{ID: licenseID})
+	}
+	volume.Licenses = licenses
+	volume.UpdatedBy = updatedBy
+
+	_, err = data.UpdateVolume(c.Request.Context(), volumeID, volume, catalogmodels.VersionStateLive)
+	return err
+}

--- a/server/licenses.go
+++ b/server/licenses.go
@@ -17,6 +17,7 @@ import (
 	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/vo"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,6 +28,10 @@ var licenseVersionConfig = entityVersionAPIConfig[vo.LicenseVO, vo.LicenseVersio
 	recordType: "license",
 	get: func(c *gin.Context, id string) (*vo.LicenseVO, error) {
 		return data.GetLicense(c.Request.Context(), id)
+	},
+	create: func(c *gin.Context, entity *vo.LicenseVO, createdBy string) (*string, error) {
+		entity.CreatedBy = createdBy
+		return data.AddLicense(c.Request.Context(), entity)
 	},
 	createVersion: func(c *gin.Context, id string, entity *vo.LicenseVO, state catalogmodels.VersionState) (*vo.LicenseVersionVO, error) {
 		return data.UpdateLicense(c.Request.Context(), id, entity, state)
@@ -91,6 +96,27 @@ var licenseVersionConfig = entityVersionAPIConfig[vo.LicenseVO, vo.LicenseVersio
 			set: func(v *vo.LicenseVO, s string) { v.Notes = s },
 		},
 	},
+	// Tags are a plain free-text label here (Name only, Value unused) - not a linked vocabulary
+	// with stable IDs like publisher/studio. Publisher/studio/person tags editing isn't part of
+	// this - only license needed it (sweetrpg/catalog-web#121).
+	arrayFields: map[string]entityArrayFieldAccessor[vo.LicenseVO]{
+		"tags": {
+			get: func(v *vo.LicenseVO) []string {
+				names := make([]string, len(v.Tags))
+				for i, t := range v.Tags {
+					names[i] = t.Name
+				}
+				return names
+			},
+			set: func(v *vo.LicenseVO, names []string) {
+				tags := make([]modelcore.TagVO, len(names))
+				for i, n := range names {
+					tags[i] = modelcore.TagVO{Name: n}
+				}
+				v.Tags = tags
+			},
+		},
+	},
 }
 
 func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cachettl.Config, authzClient *authz.Client) {
@@ -103,12 +129,14 @@ func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cach
 	g.GET("/licenses/:id/versions/:version", getEntityVersion(licenseVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
+	g.POST("/licenses", writeRoles, createEntityVersion(licenseVersionConfig))
 	g.PATCH("/licenses/:id", writeRoles, patchEntityVersion(licenseVersionConfig))
 	g.POST("/licenses/:id/versions/:version/retract", writeRoles, retractEntityVersion(licenseVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
 	g.POST("/licenses/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(licenseVersionConfig))
 	g.POST("/licenses/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(licenseVersionConfig))
+	g.PATCH("/licenses/:id/volumes", reviewRoles, patchLicenseVolumes)
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)
 	g.POST("/licenses/:id/versions/:version/current", rollbackRoles, setCurrentEntityVersion(licenseVersionConfig))

--- a/server/persons.go
+++ b/server/persons.go
@@ -27,6 +27,10 @@ var personVersionConfig = entityVersionAPIConfig[vo.PersonVO, vo.PersonVersionVO
 	get: func(c *gin.Context, id string) (*vo.PersonVO, error) {
 		return data.GetPerson(c.Request.Context(), id)
 	},
+	create: func(c *gin.Context, entity *vo.PersonVO, createdBy string) (*string, error) {
+		entity.CreatedBy = createdBy
+		return data.AddPerson(c.Request.Context(), entity)
+	},
 	createVersion: func(c *gin.Context, id string, entity *vo.PersonVO, state catalogmodels.VersionState) (*vo.PersonVersionVO, error) {
 		return data.UpdatePerson(c.Request.Context(), id, entity, state)
 	},
@@ -72,6 +76,7 @@ func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.GET("/persons/:id/versions/:version", getEntityVersion(personVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
+	g.POST("/persons", writeRoles, createEntityVersion(personVersionConfig))
 	g.PATCH("/persons/:id", writeRoles, patchEntityVersion(personVersionConfig))
 	g.POST("/persons/:id/versions/:version/retract", writeRoles, retractEntityVersion(personVersionConfig))
 

--- a/server/publishers.go
+++ b/server/publishers.go
@@ -27,6 +27,10 @@ var publisherVersionConfig = entityVersionAPIConfig[vo.PublisherVO, vo.Publisher
 	get: func(c *gin.Context, id string) (*vo.PublisherVO, error) {
 		return data.GetPublisher(c.Request.Context(), id)
 	},
+	create: func(c *gin.Context, entity *vo.PublisherVO, createdBy string) (*string, error) {
+		entity.CreatedBy = createdBy
+		return data.AddPublisher(c.Request.Context(), entity)
+	},
 	createVersion: func(c *gin.Context, id string, entity *vo.PublisherVO, state catalogmodels.VersionState) (*vo.PublisherVersionVO, error) {
 		return data.UpdatePublisher(c.Request.Context(), id, entity, state)
 	},
@@ -82,6 +86,7 @@ func setupPublisherHandlers(g *gin.Engine, store persistence.CacheStore, ttls ca
 	g.GET("/publishers/:id/versions/:version", getEntityVersion(publisherVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
+	g.POST("/publishers", writeRoles, createEntityVersion(publisherVersionConfig))
 	g.PATCH("/publishers/:id", writeRoles, patchEntityVersion(publisherVersionConfig))
 	g.POST("/publishers/:id/versions/:version/retract", writeRoles, retractEntityVersion(publisherVersionConfig))
 

--- a/server/studios.go
+++ b/server/studios.go
@@ -27,6 +27,10 @@ var studioVersionConfig = entityVersionAPIConfig[vo.StudioVO, vo.StudioVersionVO
 	get: func(c *gin.Context, id string) (*vo.StudioVO, error) {
 		return data.GetStudio(c.Request.Context(), id)
 	},
+	create: func(c *gin.Context, entity *vo.StudioVO, createdBy string) (*string, error) {
+		entity.CreatedBy = createdBy
+		return data.AddStudio(c.Request.Context(), entity)
+	},
 	createVersion: func(c *gin.Context, id string, entity *vo.StudioVO, state catalogmodels.VersionState) (*vo.StudioVersionVO, error) {
 		return data.UpdateStudio(c.Request.Context(), id, entity, state)
 	},
@@ -78,6 +82,7 @@ func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.GET("/studios/:id/versions/:version", getEntityVersion(studioVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
+	g.POST("/studios", writeRoles, createEntityVersion(studioVersionConfig))
 	g.PATCH("/studios/:id", writeRoles, patchEntityVersion(studioVersionConfig))
 	g.POST("/studios/:id/versions/:version/retract", writeRoles, retractEntityVersion(studioVersionConfig))
 


### PR DESCRIPTION
## Summary
- `POST /licenses`, `/publishers`, `/studios`, `/persons` - generic create route, wired to the
  already-existing `data.AddLicense`/`AddPublisher`/`AddStudio`/`AddPerson` (these were present
  in catalog-data.go v0.9.0 but never had a catalog-api route). Always creates live (no "submitted
  for review" concept for a record with no prior version). `writeRoles` (admin/editor/submitter),
  same tier as PATCH.
- `entityVersionAPIConfig` gains `arrayFields` for `[]string`-typed PATCH fields (alongside the
  existing string-only `fields`). Applied to license `tags` only - publisher/studio/person tags
  editing is out of scope here.
- `PATCH /licenses/:id/volumes` (`{"volumeIds": [...]}`, editor/admin only) sets a license's full
  associated-volumes set. License<->volume is volume-owned data (`vo.VolumeVO.Licenses`), so this
  diffs the request against the current reverse-lookup query and updates each affected volume's
  own `Licenses` field via the existing `UpdateVolume` path - not transactional, matches this
  codebase's existing multi-entity fetch/update loops (`applyVolumePatch`'s own Publisher/Studio
  ID handling).

Backend half of sweetrpg/catalog-web#119 and sweetrpg/catalog-web#121 - the frontend work
(create forms, license edit tag/volume pickers) is a separate PR against catalog-web once this
merges and releases.

## Wire contract for the frontend
- `POST /licenses` (and /publishers, /studios, /persons): body is the full entity JSON:API
  attributes (same shape PATCH already accepts per-field), no `id`. `201` + full JSON:API record
  on success.
- `PATCH /licenses/:id`: `tags` now accepts a JSON array of strings (was previously not a
  recognized field at all - a request containing only `tags` used to 400 with "no recognized
  fields to change").
- `PATCH /licenses/:id/volumes`: `{"volumeIds": ["<id>", ...]}`, full-replace semantics
  (matching `PublisherIDs`/`StudioIDs` on the volume PATCH route). `200` + the license's updated
  volume list (JSON:API) on success.

## Test plan
- [x] `go build ./server/... ./cmd/...`
- [x] `go vet ./server/... ./cmd/...`
- [x] `go test ./server/... ./cmd/... ./cachettl/... ./ratelimit/...`
- [ ] Manual smoke test against a local Mongo (no server/ handler test coverage exists in this
      repo today - a documented pre-existing gap, see AGENTS.md's "Known gaps")