### PR TITLE
Fix Deployment fields that never matched ArgoCD's applied manifest

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -65,7 +65,7 @@ spec:
                           cpu: "20m"
                           memory: "55Mi"
                       limits:
-                          cpu: "1.0"
+                          cpu: "1"
                           memory: "1Gi"
                   livenessProbe:
                         httpGet:
@@ -73,7 +73,7 @@ spec:
                             port: http
                         initialDelaySeconds: 90
                         timeoutSeconds: 10
-                        interval: 10
+                        periodSeconds: 10
                   readinessProbe:
                         # Deliberately the shallow /status/ping, not /status/health - readiness
                         # gates whether this pod receives traffic at all, and /status/health does


### PR DESCRIPTION
## Summary
Found while diagnosing why sweetrpg-catalog-api perpetually reports OutOfSync in ArgoCD despite
being Healthy and running the correct image (\`argocd app diff\`):

- \`livenessProbe.interval: 10\` should be \`periodSeconds: 10\` (readinessProbe already has
  this right) - \`interval\` isn't a real Probe field, the API server silently drops it, so the
  live object never matches the desired manifest.
- \`resources.limits.cpu: "1.0"\` - Kubernetes always normalizes a live Quantity to \`"1"\`, so
  this never matched either.

Neither caused a functional problem - the probe just used its Kubernetes default periodSeconds
instead of the explicit value, and the CPU limit still applied - but they permanently pollute
the ArgoCD sync status, which is exactly the signal you'd want to actually trust for real drift.

A separate real (and legitimate) source of drift - Stakater Reloader injecting
STAKATER_*_CONFIGMAP/SECRET env vars into this same Deployment - is handled via
\`ignoreDifferences\` on the Application manifest in \`sweetrpg/kubernetes\`, not here.

## Test plan
- [ ] Confirm \`argocd app diff sweetrpg-catalog-api\` is empty after this ships and syncs