### PR TITLE
chore: point REDIS_HOST at renamed cache Service

### DIFF
--- a/kubernetes/overlays/dev/configmaps.yaml
+++ b/kubernetes/overlays/dev/configmaps.yaml
@@ -21,10 +21,10 @@ data:
   PYROSCOPE_TENANT_ID: psw
   SENTRY_RELEASE: "1"
   # The infra repo's catalog/cache chart migrated from Bitnami's redis chart (which used a
-  # "<release>-master" Service name) to the Valkey chart with fullnameOverride: redis - the
-  # Service is just "redis" now. "redis-master" never resolved, which is part of why this was
+  # "<release>-master" Service name) to the Valkey chart with fullnameOverride: cache - the
+  # Service is just "cache" now. "redis-master" never resolved, which is part of why this was
   # never exercised end-to-end. See openspec/changes/catalog-api-caching-rate-limiting.
-  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
+  REDIS_HOST: cache.sweetrpg-catalog.svc.cluster.local
   REDIS_PORT: "6379"
   CACHE_TTLS: "licenses=30m,volumes=30m,systems=2h,publishers=2h,studios=2h,persons=1h,contributions=1h,reviews=15m"
   CACHE_DEFAULT_TTL: 1h

--- a/kubernetes/overlays/local/configmaps.yaml
+++ b/kubernetes/overlays/local/configmaps.yaml
@@ -18,7 +18,7 @@ data:
   BUILD_INFO_PATH: /app/config/build-info.json
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo-distributor.observability.svc.cluster.local:4318/
   SENTRY_RELEASE: "1"
-  REDIS_HOST: redis.sweetrpg-catalog.svc.cluster.local
+  REDIS_HOST: cache.sweetrpg-catalog.svc.cluster.local
   REDIS_PORT: "6379"
   # Traefik strips /api/0/catalog (or /1) before the request reaches this app (see
   # middlewares.yaml) - every self-referencing link this app generates needs the full prefix


### PR DESCRIPTION
## Summary
- catalog/cache's Helm release (support/infrastructure) was renamed from `redis` to `cache`
- Repoints REDIS_HOST at the new Service name in dev/local overlays

## Test plan
- [ ] ArgoCD sync picks up the new configmap value
- [ ] Cache reads/writes succeed against the renamed Service in dev