### PR TITLE
fix(volumes): add game system association, cache invalidation, studio volume patching

### DIFF
--- a/server/cache_invalidate.go
+++ b/server/cache_invalidate.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"github.com/gin-contrib/cache"
+	"github.com/gin-contrib/cache/persistence"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+)
+
+// invalidateCachedPaths deletes catalog-api's Redis-backed GET response cache (see
+// docs/service-conventions.md's Caching section) for each given request path - best-effort, same
+// "a cache miss just costs one extra backend fetch" tolerance CachePage itself has. No write path
+// in this service invalidated this cache before - see the entity-association write paths that
+// call this (applyVolumePatch, patchLicenseVolumes, patchStudioVolumes) - so a changed
+// association (e.g. a volume newly linked to a publisher) stayed stale on that publisher's
+// browse-card volume count and detail page for the rest of CACHE_TTLS' window (tens of minutes),
+// not just until the writing request's own response.
+func invalidateCachedPaths(store persistence.CacheStore, paths ...string) {
+	for _, p := range paths {
+		_ = store.Delete(cache.CreateKey(p))
+	}
+}
+
+// invalidateVolumeAssociationCache invalidates every cached GET response a change to before's/
+// after's Publishers/Studios/Systems could have made stale: each affected entity's own
+// `/<type>/<id>` and `/<type>/<id>/volumes` (its browse-card volume count and detail page), each
+// affected type's top-level list (`/publishers`, `/studios`, `/systems`), and the volume's own
+// `/volumes/<id>` and `/volumes` list. Called with both the pre- and post-patch volume so an id
+// that was removed gets invalidated too, not just one newly added.
+func invalidateVolumeAssociationCache(store persistence.CacheStore, before, after *vo.VolumeVO) {
+	paths := []string{"/volumes", "/volumes/" + before.ID, "/publishers", "/studios", "/systems"}
+	for _, id := range unionPublisherIDs(before.Publishers, after.Publishers) {
+		paths = append(paths, "/publishers/"+id, "/publishers/"+id+"/volumes")
+	}
+	for _, id := range unionStudioIDs(before.Studios, after.Studios) {
+		paths = append(paths, "/studios/"+id, "/studios/"+id+"/volumes")
+	}
+	for _, id := range unionSystemIDs(before.Systems, after.Systems) {
+		paths = append(paths, "/systems/"+id, "/systems/"+id+"/volumes")
+	}
+	invalidateCachedPaths(store, paths...)
+}
+
+func unionPublisherIDs(a, b []*vo.PublisherVO) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, p := range append(append([]*vo.PublisherVO{}, a...), b...) {
+		if p != nil && !seen[p.ID] {
+			seen[p.ID] = true
+			ids = append(ids, p.ID)
+		}
+	}
+	return ids
+}
+
+func unionStudioIDs(a, b []*vo.StudioVO) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, s := range append(append([]*vo.StudioVO{}, a...), b...) {
+		if s != nil && !seen[s.ID] {
+			seen[s.ID] = true
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}
+
+// invalidateLicenseVolumesCache invalidates the license's own cached paths, the top-level
+// `/licenses` list, and every affected volume's `/volumes/<id>` (a volume's license badge on its
+// own detail page would otherwise stay stale too) after a `patchLicenseVolumes` full-replace.
+func invalidateLicenseVolumesCache(store persistence.CacheStore, licenseID string, before, after []string) {
+	paths := []string{
+		"/licenses", "/licenses/" + licenseID, "/licenses/" + licenseID + "/volumes", "/volumes",
+	}
+	for _, vid := range unionStrings(before, after) {
+		paths = append(paths, "/volumes/"+vid)
+	}
+	invalidateCachedPaths(store, paths...)
+}
+
+// invalidateStudioVolumesCache is invalidateLicenseVolumesCache's studio counterpart.
+func invalidateStudioVolumesCache(store persistence.CacheStore, studioID string, before, after []string) {
+	paths := []string{
+		"/studios", "/studios/" + studioID, "/studios/" + studioID + "/volumes", "/volumes",
+	}
+	for _, vid := range unionStrings(before, after) {
+		paths = append(paths, "/volumes/"+vid)
+	}
+	invalidateCachedPaths(store, paths...)
+}
+
+func unionStrings(a, b []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range append(append([]string{}, a...), b...) {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func unionSystemIDs(a, b []*vo.SystemVO) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, s := range append(append([]*vo.SystemVO{}, a...), b...) {
+		if s != nil && !seen[s.ID] {
+			seen[s.ID] = true
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}

--- a/server/licenses.go
+++ b/server/licenses.go
@@ -136,7 +136,9 @@ func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cach
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
 	g.POST("/licenses/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(licenseVersionConfig))
 	g.POST("/licenses/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(licenseVersionConfig))
-	g.PATCH("/licenses/:id/volumes", reviewRoles, patchLicenseVolumes)
+	g.PATCH("/licenses/:id/volumes", reviewRoles, func(c *gin.Context) {
+		patchLicenseVolumes(c, store)
+	})
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)
 	g.POST("/licenses/:id/versions/:version/current", rollbackRoles, setCurrentEntityVersion(licenseVersionConfig))

--- a/server/studio_volumes.go
+++ b/server/studio_volumes.go
@@ -15,23 +15,23 @@ import (
 	"github.com/sweetrpg/catalog-objects.go/vo"
 )
 
-type patchLicenseVolumesRequest struct {
+type patchStudioVolumesRequest struct {
 	VolumeIDs []string `json:"volumeIds"`
 }
 
-// fetchLicenseVolumes returns every volume currently referencing a license - mirrors
-// getLicenseVolumes' own query (license_ids $in [id]), factored out here since this handler
-// needs to call it twice (before and after the diff below).
-func fetchLicenseVolumes(c *gin.Context, licenseID string) ([]*vo.VolumeVO, error) {
+// fetchStudioVolumesForPatch returns every volume currently referencing a studio - mirrors
+// getStudioVolumes' own query (studio_ids $in [id]), factored out here since this handler needs
+// to call it twice (before and after the diff below).
+func fetchStudioVolumesForPatch(c *gin.Context, studioID string) ([]*vo.VolumeVO, error) {
 	inOp := "$in"
 	params := apiutil.QueryParams{
-		Filter: []apiutil.Filter{{Field: "license_ids", Operation: &inOp, Value: []string{licenseID}}},
+		Filter: []apiutil.Filter{{Field: "studio_ids", Operation: &inOp, Value: []string{studioID}}},
 	}
 	return data.QueryVolumes(c.Request.Context(), params)
 }
 
-func fetchLicenseVolumeIDs(c *gin.Context, licenseID string) ([]string, error) {
-	volumes, err := fetchLicenseVolumes(c, licenseID)
+func fetchStudioVolumeIDs(c *gin.Context, studioID string) ([]string, error) {
+	volumes, err := fetchStudioVolumesForPatch(c, studioID)
 	if err != nil {
 		return nil, err
 	}
@@ -42,37 +42,33 @@ func fetchLicenseVolumeIDs(c *gin.Context, licenseID string) ([]string, error) {
 	return ids, nil
 }
 
-// patchLicenseVolumes sets the complete list of volumes a license is associated with - full
-// replace semantics, same convention volumes_patch.go's own PublisherIDs/StudioIDs already use.
-// License<->volume association is volume-owned data (vo.VolumeVO.Licenses), not license-owned -
-// getLicenseVolumes/fetchLicenseVolumeIDs above read it via a reverse query for exactly that
-// reason. So this diffs the requested set against the current one and, for each added/removed
-// volume, updates that volume's own Licenses field directly (editor/admin only - this route
-// writes to records other than the one named in the URL, same tier as accept/reject, not open to
-// submitters). Not transactional - matches this codebase's existing multi-entity fetch/update
-// loops (e.g. applyVolumePatch's own Publisher/Studio ID resolution), which don't use Mongo
-// transactions either.
-func patchLicenseVolumes(c *gin.Context, store persistence.CacheStore) {
+// patchStudioVolumes sets the complete list of volumes a studio is associated with - full
+// replace semantics, same convention patchLicenseVolumes uses (see license_volumes.go's own
+// comment for the rationale: studio<->volume association is volume-owned data, not
+// studio-owned, so this diffs the requested set against the current one and updates each
+// added/removed volume's own Studios field directly). Editor/admin only, same tier as
+// patchLicenseVolumes - this route writes to records other than the one named in the URL.
+func patchStudioVolumes(c *gin.Context, store persistence.CacheStore) {
 	id := c.Param("id")
 
-	license, err := data.GetLicense(c.Request.Context(), id)
+	studio, err := data.GetStudio(c.Request.Context(), id)
 	if err != nil {
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
-	if license == nil {
+	if studio == nil {
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
 
-	var req patchLicenseVolumesRequest
+	var req patchStudioVolumesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 		return
 	}
 
-	currentIDs, err := fetchLicenseVolumeIDs(c, id)
+	currentIDs, err := fetchStudioVolumeIDs(c, id)
 	if err != nil {
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
@@ -94,7 +90,7 @@ func patchLicenseVolumes(c *gin.Context, store persistence.CacheStore) {
 		if current[vid] {
 			continue
 		}
-		if err := setVolumeHasLicense(c, vid, id, true, updatedBy); err != nil {
+		if err := setVolumeHasStudio(c, vid, id, true, updatedBy); err != nil {
 			sentry.CaptureException(err)
 		}
 	}
@@ -102,14 +98,14 @@ func patchLicenseVolumes(c *gin.Context, store persistence.CacheStore) {
 		if requested[vid] {
 			continue
 		}
-		if err := setVolumeHasLicense(c, vid, id, false, updatedBy); err != nil {
+		if err := setVolumeHasStudio(c, vid, id, false, updatedBy); err != nil {
 			sentry.CaptureException(err)
 		}
 	}
 
-	invalidateLicenseVolumesCache(store, id, currentIDs, req.VolumeIDs)
+	invalidateStudioVolumesCache(store, id, currentIDs, req.VolumeIDs)
 
-	volumes, err := fetchLicenseVolumes(c, id)
+	volumes, err := fetchStudioVolumesForPatch(c, id)
 	if err != nil {
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
@@ -123,11 +119,10 @@ func patchLicenseVolumes(c *gin.Context, store persistence.CacheStore) {
 	}
 }
 
-// setVolumeHasLicense adds or removes one license ID from a volume's Licenses relation and saves
+// setVolumeHasStudio adds or removes one studio ID from a volume's Studios relation and saves
 // the volume live - a full-record UpdateVolume, since that's the only write path this data layer
-// exposes for volume (matches PublisherIDs/StudioIDs' own "id-only stub is enough, UpdateVolume
-// re-resolves the full relation" convention in applyVolumePatch).
-func setVolumeHasLicense(c *gin.Context, volumeID, licenseID string, add bool, updatedBy string) error {
+// exposes for volume (mirrors setVolumeHasLicense).
+func setVolumeHasStudio(c *gin.Context, volumeID, studioID string, add bool, updatedBy string) error {
 	volume, err := data.GetVolume(c.Request.Context(), volumeID)
 	if err != nil {
 		return err
@@ -136,21 +131,21 @@ func setVolumeHasLicense(c *gin.Context, volumeID, licenseID string, add bool, u
 		return nil
 	}
 
-	licenses := make([]*vo.LicenseVO, 0, len(volume.Licenses)+1)
+	studios := make([]*vo.StudioVO, 0, len(volume.Studios)+1)
 	found := false
-	for _, l := range volume.Licenses {
-		if l.ID == licenseID {
+	for _, s := range volume.Studios {
+		if s.ID == studioID {
 			found = true
 			if !add {
 				continue
 			}
 		}
-		licenses = append(licenses, l)
+		studios = append(studios, s)
 	}
 	if add && !found {
-		licenses = append(licenses, &vo.LicenseVO{ID: licenseID})
+		studios = append(studios, &vo.StudioVO{ID: studioID})
 	}
-	volume.Licenses = licenses
+	volume.Studios = studios
 	volume.UpdatedBy = updatedBy
 
 	_, err = data.UpdateVolume(c.Request.Context(), volumeID, volume, catalogmodels.VersionStateLive)

--- a/server/studios.go
+++ b/server/studios.go
@@ -89,6 +89,9 @@ func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
 	g.POST("/studios/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(studioVersionConfig))
 	g.POST("/studios/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(studioVersionConfig))
+	g.PATCH("/studios/:id/volumes", reviewRoles, func(c *gin.Context) {
+		patchStudioVolumes(c, store)
+	})
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)
 	g.POST("/studios/:id/versions/:version/current", rollbackRoles, setCurrentEntityVersion(studioVersionConfig))

--- a/server/volumes.go
+++ b/server/volumes.go
@@ -32,9 +32,11 @@ func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	// g.GET("/volumes/:id/volumes", cache.CachePage(store, ttl, getVolumeVolumes))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.PATCH("/volumes/:id", writeRoles, patchVolume)
+	g.PATCH("/volumes/:id", writeRoles, func(c *gin.Context) {
+		patchVolume(c, store)
+	})
 	g.POST("/volumes/:id/finalize-session", writeRoles, func(c *gin.Context) {
-		finalizeVolumeSession(c, assetsClient, editSessions)
+		finalizeVolumeSession(c, assetsClient, editSessions, store)
 	})
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)

--- a/server/volumes_finalize.go
+++ b/server/volumes_finalize.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	apiv "github.com/sweetrpg/api-core.go/vo"
 	"github.com/sweetrpg/catalog-api/assets"
@@ -34,7 +35,10 @@ const recordTypeVolume = "volume"
 //	@Failure		404	{object}	apiv.ErrorVO
 //	@Failure		500	{object}	apiv.ErrorVO
 //	@Router			/volumes/{id}/finalize-session [post]
-func finalizeVolumeSession(c *gin.Context, assetsClient *assets.Client, editSessions *editsession.Store) {
+func finalizeVolumeSession(
+	c *gin.Context, assetsClient *assets.Client, editSessions *editsession.Store,
+	store persistence.CacheStore,
+) {
 	volumeID := c.Param("id")
 	userID := authz.Subject(c)
 
@@ -99,7 +103,7 @@ func finalizeVolumeSession(c *gin.Context, assetsClient *assets.Client, editSess
 			req.SampleAssetIds = &liveSampleIds
 		}
 
-		if !applyVolumePatch(c, existing, req, models.VersionStateLive) {
+		if !applyVolumePatch(c, existing, req, models.VersionStateLive, store) {
 			return
 		}
 		if err := editSessions.Delete(c.Request.Context(), userID, recordTypeVolume); err != nil {

--- a/server/volumes_patch.go
+++ b/server/volumes_patch.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"github.com/google/jsonapi"
 	apiv "github.com/sweetrpg/api-core.go/vo"
@@ -36,9 +37,9 @@ const maxSampleAssetIds = 5
 // patchVolumeRequest's fields are pointers so an absent field (nil) is distinguishable from an
 // explicit empty string/omitted array - only present fields are part of the edit/submission.
 //
-// Properties/PublisherIDs/StudioIDs/Credits/Format/CoverAssetId/SampleAssetIds are editor/admin
-// -only by policy (see hasEditorOnlyFields) - a submitter request touching any of them is
-// rejected with a clear error rather than silently dropping the field.
+// Properties/PublisherIDs/StudioIDs/SystemIDs/Credits/Format/CoverAssetId/SampleAssetIds are
+// editor/admin-only by policy (see hasEditorOnlyFields) - a submitter request touching any of
+// them is rejected with a clear error rather than silently dropping the field.
 type patchVolumeRequest struct {
 	Title          *string            `json:"title"`
 	Description    *string            `json:"description"`
@@ -46,6 +47,7 @@ type patchVolumeRequest struct {
 	Properties     *[]propertyRequest `json:"properties"`
 	PublisherIDs   *[]string          `json:"publisherIds"`
 	StudioIDs      *[]string          `json:"studioIds"`
+	SystemIDs      *[]string          `json:"systemIds"`
 	Credits        *[]creditRequest   `json:"credits"`
 	Format         *string            `json:"format"`
 	CoverAssetId   *string            `json:"coverAssetId"`
@@ -56,7 +58,8 @@ type patchVolumeRequest struct {
 // (see patchVolumeRequest's doc comment).
 func (req patchVolumeRequest) hasEditorOnlyFields() bool {
 	return req.Properties != nil || req.PublisherIDs != nil || req.StudioIDs != nil ||
-		req.Credits != nil || req.Format != nil || req.CoverAssetId != nil || req.SampleAssetIds != nil
+		req.SystemIDs != nil || req.Credits != nil || req.Format != nil ||
+		req.CoverAssetId != nil || req.SampleAssetIds != nil
 }
 
 // submittedVersionResponse is returned when a submitter's PATCH creates a submitted version
@@ -82,7 +85,7 @@ type submittedVersionResponse struct {
 //	@Failure		404		{object}	apiv.ErrorVO
 //	@Failure		500		{object}	apiv.ErrorVO
 //	@Router			/volumes/{id} [patch]
-func patchVolume(c *gin.Context) {
+func patchVolume(c *gin.Context, store persistence.CacheStore) {
 	id := c.Param("id")
 
 	var req patchVolumeRequest
@@ -116,7 +119,7 @@ func patchVolume(c *gin.Context) {
 	if !isEditor && req.hasEditorOnlyFields() {
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{
 			Error:   "unsupported_field",
-			Message: "properties, publisherIds, studioIds, credits, format, coverAssetId, and sampleAssetIds can't be submitted - an editor or admin must make this change directly",
+			Message: "properties, publisherIds, studioIds, systemIds, credits, format, coverAssetId, and sampleAssetIds can't be submitted - an editor or admin must make this change directly",
 		})
 		return
 	}
@@ -125,7 +128,7 @@ func patchVolume(c *gin.Context) {
 	if isEditor {
 		state = catalogmodels.VersionStateLive
 	}
-	applyVolumePatch(c, existing, req, state)
+	applyVolumePatch(c, existing, req, state, store)
 }
 
 // hasSubmittableFields reports whether req touches a field a submitter is allowed to change
@@ -142,7 +145,10 @@ func (req patchVolumeRequest) hasSubmittableFields() bool {
 // response, success or failure, has always already been written either way) - callers that have
 // follow-up cleanup contingent on success (finalizeVolumeSession deleting the now-applied
 // session) need to know which happened.
-func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequest, state catalogmodels.VersionState) bool {
+func applyVolumePatch(
+	c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequest, state catalogmodels.VersionState,
+	store persistence.CacheStore,
+) bool {
 	updated := *existing
 	if req.Title != nil {
 		updated.Title = *req.Title
@@ -173,6 +179,13 @@ func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequ
 			studios[i] = &vo.StudioVO{ID: id}
 		}
 		updated.Studios = studios
+	}
+	if req.SystemIDs != nil {
+		systems := make([]*vo.SystemVO, len(*req.SystemIDs))
+		for i, id := range *req.SystemIDs {
+			systems[i] = &vo.SystemVO{ID: id}
+		}
+		updated.Systems = systems
 	}
 	if req.Format != nil {
 		updated.Format = *req.Format
@@ -218,6 +231,10 @@ func applyVolumePatch(c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequ
 			Message: "Change submitted for review",
 		})
 		return true
+	}
+
+	if req.PublisherIDs != nil || req.StudioIDs != nil || req.SystemIDs != nil {
+		invalidateVolumeAssociationCache(store, existing, &updated)
 	}
 
 	result, err := data.GetVolume(c.Request.Context(), existing.ID)

--- a/vocabularies/model.go
+++ b/vocabularies/model.go
@@ -14,10 +14,11 @@ const (
 	TypeContributionType = "contribution-type"
 	TypePropertyName     = "property-name"
 	TypeFormat           = "format"
+	TypeTag              = "tag"
 )
 
 // ValidTypes lists every recognized :type path value.
-var ValidTypes = []string{TypeContributionType, TypePropertyName, TypeFormat}
+var ValidTypes = []string{TypeContributionType, TypePropertyName, TypeFormat, TypeTag}
 
 // IsValidType reports whether t is a recognized vocabulary type.
 func IsValidType(t string) bool {


### PR DESCRIPTION
## Summary
- Adds `SystemIDs` to `patchVolumeRequest` - the volume edit page's system association was silently unimplemented (`Volume.Systems` existed, nothing wired it into the PATCH request).
- Adds `invalidateCachedPaths`/`invalidateVolumeAssociationCache` and wires them into `applyVolumePatch` and `patchLicenseVolumes` - no write path invalidated catalog-api's Redis response cache before, so a newly linked publisher/studio/system/license kept showing a stale volume count for the rest of `CACHE_TTLS`' window.
- Adds `patchStudioVolumes` (`PATCH /studios/:id/volumes`), mirroring `patchLicenseVolumes` - studios had a GET but no write path.
- Adds `tag` as a valid shared-vocabulary type, for catalog-web's new license tags picker.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manual: link a volume to a publisher/studio/system, confirm the entity's own browse card/detail page reflects the new volume count immediately (not after cache TTL)