### PR TITLE
Bulk-create endpoint for persons (POST /persons/bulk)

### DIFF
--- a/server/entity_version_patch.go
+++ b/server/entity_version_patch.go
@@ -89,6 +89,65 @@ func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Han
 	}
 }
 
+// bulkCreateResult is one entry's outcome in a bulkCreateEntityVersion response - success/id for
+// a created record, or an error message, never both.
+type bulkCreateResult struct {
+	Success bool    `json:"success"`
+	ID      *string `json:"id,omitempty"`
+	Error   *string `json:"error,omitempty"`
+}
+
+// bulkCreateEntityVersion creates N brand-new records from a single request, mirroring
+// createEntityVersion per entry rather than reusing it directly (createEntityVersion writes its
+// own response per call; this needs to collect N outcomes into one response instead). Each entry
+// succeeds or fails independently - one bad entry (e.g. a blank required field) does not block
+// the rest of the batch, per catalog-entity-bulk-add's spec. If cfg.fields has a "name" field
+// (every current bulk-create consumer, e.g. Person, keys its required display name that way),
+// a blank value fails that entry before ever reaching cfg.create - this generic engine has no
+// other validation of its own.
+func bulkCreateEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var rawEntries []json.RawMessage
+		if err := c.ShouldBindJSON(&rawEntries); err != nil {
+			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
+			return
+		}
+
+		createdBy := authz.Subject(c)
+		results := make([]bulkCreateResult, len(rawEntries))
+		for i, raw := range rawEntries {
+			var entity T
+			if err := json.Unmarshal(raw, &entity); err != nil {
+				msg := err.Error()
+				results[i] = bulkCreateResult{Error: &msg}
+				continue
+			}
+
+			if nameField, ok := cfg.fields["name"]; ok && nameField.get(&entity) == "" {
+				msg := "name is required"
+				results[i] = bulkCreateResult{Error: &msg}
+				continue
+			}
+
+			id, err := cfg.create(c, &entity, createdBy)
+			if err != nil {
+				sentry.CaptureException(err)
+				msg := err.Error()
+				results[i] = bulkCreateResult{Error: &msg}
+				continue
+			}
+			if id == nil {
+				msg := "no id returned"
+				results[i] = bulkCreateResult{Error: &msg}
+				continue
+			}
+			results[i] = bulkCreateResult{Success: true, ID: id}
+		}
+
+		c.JSON(http.StatusOK, gin.H{"results": results})
+	}
+}
+
 // patchEntityVersion edits an entity, or submits an edit for review, creating a version either
 // way - the version-model counterpart of patchEntity.
 func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {

--- a/server/entity_version_patch_test.go
+++ b/server/entity_version_patch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
+	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-api/authz"
 	"github.com/sweetrpg/catalog-api/cachettl"
 	"github.com/sweetrpg/catalog-data.go/data"
@@ -123,5 +124,121 @@ func TestAddStudioThenListAndGetVersions(t *testing.T) {
 	}
 	if len(versions) != 2 {
 		t.Fatalf("len(versions) = %d, want 2", len(versions))
+	}
+}
+
+// newPersonBulkTestRouter mirrors newStudioTestRouter, against setupPersonHandlers -
+// bulkCreateEntityVersion (server/entity_version_patch.go) is generic like the rest of this
+// engine, but bulk-add-persons only wires it up for Person (catalog-entity-bulk-add's scope),
+// so it's exercised here rather than against studio.
+func newPersonBulkTestRouter(t *testing.T, roles []string) *gin.Engine {
+	t.Helper()
+
+	authAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(authz.CheckResponse{Allowed: true, Roles: roles, Sub: "auth0|test-reviewer"})
+	}))
+	t.Cleanup(authAPI.Close)
+
+	r := gin.New()
+	setupPersonHandlers(r, persistence.NewInMemoryStore(0), cachettl.Config{}, authz.NewClient(authAPI.URL))
+	return r
+}
+
+func TestBulkCreatePersonsAllValid(t *testing.T) {
+	r := newPersonBulkTestRouter(t, []string{authz.RoleEditor})
+
+	rec := doPost(t, r, "/persons/bulk", []map[string]string{
+		{"name": "Ann Leckie"},
+		{"name": "N.K. Jemisin"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Results []bulkCreateResult `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(resp.Results))
+	}
+	for i, result := range resp.Results {
+		if !result.Success || result.ID == nil {
+			t.Errorf("results[%d] = %+v, want success with an id", i, result)
+		}
+	}
+}
+
+func TestBulkCreatePersonsMixedValidAndInvalid(t *testing.T) {
+	r := newPersonBulkTestRouter(t, []string{authz.RoleEditor})
+
+	rec := doPost(t, r, "/persons/bulk", []map[string]string{
+		{"name": "Valid One"},
+		{"name": ""},
+		{"name": "Valid Two"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Results []bulkCreateResult `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(resp.Results))
+	}
+	if !resp.Results[0].Success {
+		t.Errorf("results[0] = %+v, want success", resp.Results[0])
+	}
+	if resp.Results[1].Success || resp.Results[1].Error == nil {
+		t.Errorf("results[1] = %+v, want a failure with an error message", resp.Results[1])
+	}
+	if !resp.Results[2].Success {
+		t.Errorf("results[2] = %+v, want success (a bad entry must not block later entries)", resp.Results[2])
+	}
+
+	all, err := data.QueryPersons(t.Context(), apiutil.QueryParams{})
+	if err != nil {
+		t.Fatalf("QueryPersons() error = %v", err)
+	}
+	names := make(map[string]bool, len(all))
+	for _, p := range all {
+		names[p.Name] = true
+	}
+	if !names["Valid One"] || !names["Valid Two"] {
+		t.Errorf("expected both valid entries to be persisted, got names: %v", names)
+	}
+}
+
+func TestBulkCreatePersonsEmptyBatch(t *testing.T) {
+	r := newPersonBulkTestRouter(t, []string{authz.RoleEditor})
+
+	rec := doPost(t, r, "/persons/bulk", []map[string]string{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Results []bulkCreateResult `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Results) != 0 {
+		t.Fatalf("len(results) = %d, want 0", len(resp.Results))
+	}
+}
+
+func TestBulkCreatePersonsSubmitterForbidden(t *testing.T) {
+	r := newPersonBulkTestRouter(t, []string{authz.RoleSubmitter})
+
+	rec := doPost(t, r, "/persons/bulk", []map[string]string{{"name": "Should Not Be Created"}})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
 }

--- a/server/persons.go
+++ b/server/persons.go
@@ -83,6 +83,9 @@ func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
 	g.POST("/persons/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(personVersionConfig))
 	g.POST("/persons/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(personVersionConfig))
+	// Bulk-create is narrower than single-entity create (writeRoles, above) - editor/admin only,
+	// no submitter path, per catalog-entity-bulk-add's spec (matches reviewRoles' tier).
+	g.POST("/persons/bulk", reviewRoles, bulkCreateEntityVersion(personVersionConfig))
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)
 	g.POST("/persons/:id/versions/:version/current", rollbackRoles, setCurrentEntityVersion(personVersionConfig))


### PR DESCRIPTION
Backend half of bulk-add-persons: generic bulkCreateEntityVersion[T,V] handler,
wired up at POST /persons/bulk (reviewRoles: editor/admin). Each entry in the
request array succeeds or fails independently - the response is a per-entry
results array so the frontend can show which names didn't take and why.

Part of #50 (sweetrpg/platform).