### PR TITLE
fix(cache): invalidate response cache on entity create/patch/accept

### DIFF
--- a/server/entity_version_patch.go
+++ b/server/entity_version_patch.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"github.com/google/jsonapi"
 	apiv "github.com/sweetrpg/api-core.go/vo"
@@ -36,7 +37,14 @@ type entityArrayFieldAccessor[T any] struct {
 // the former entity_patch.go's proposed_changes-based generic mechanism once every type using it
 // migrated onto the version model (task group 7).
 type entityVersionAPIConfig[T any, V any] struct {
-	recordType        string
+	recordType string
+	// listPath is this type's top-level list route (e.g. "/persons") - invalidated, along with
+	// the affected record's own "<listPath>/<id>", whenever create/patch/accept changes what a
+	// GET to either would return. Response caching (cache.CachePage) predates the version model;
+	// nothing in this generic flow invalidated it before, so a newly created record (or an
+	// applied/accepted edit) stayed invisible in list/detail responses for the rest of
+	// CACHE_TTLS' window.
+	listPath          string
 	fields            map[string]entityFieldAccessor[T]
 	arrayFields       map[string]entityArrayFieldAccessor[T]
 	get               func(c *gin.Context, id string) (*T, error)
@@ -56,7 +64,7 @@ type entityVersionAPIConfig[T any, V any] struct {
 // is no "submitted for review" state for a record that doesn't exist yet to compare a submission
 // against, so every role able to reach this route (writeRoles - admin/editor/submitter, same as
 // patchEntityVersion's own gate) creates the record directly.
-func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
+func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var entity T
 		if err := c.ShouldBindJSON(&entity); err != nil {
@@ -74,6 +82,7 @@ func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Han
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "create_failed", Message: "no id returned"})
 			return
 		}
+		invalidateCachedPaths(store, cfg.listPath, cfg.listPath+"/"+*id)
 
 		result, err := cfg.get(c, *id)
 		if err != nil {
@@ -91,7 +100,7 @@ func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Han
 
 // patchEntityVersion edits an entity, or submits an edit for review, creating a version either
 // way - the version-model counterpart of patchEntity.
-func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
+func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 
@@ -179,6 +188,7 @@ func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Hand
 			})
 			return
 		}
+		invalidateCachedPaths(store, cfg.listPath, cfg.listPath+"/"+id)
 
 		result, err := cfg.get(c, id)
 		if err != nil {
@@ -238,7 +248,7 @@ func getEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Handle
 }
 
 // acceptEntityVersion accepts a submitted version, in full or in part.
-func acceptEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
+func acceptEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 		version, ok := entityVersionParam(c)
@@ -260,6 +270,7 @@ func acceptEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Han
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "accept_failed", Message: err.Error()})
 			return
 		}
+		invalidateCachedPaths(store, cfg.listPath, cfg.listPath+"/"+id)
 		c.JSON(http.StatusOK, reviewVersionResponse{
 			Version: cfg.versionNumber(accepted), State: cfg.versionState(accepted), Conflicts: conflicts,
 		})

--- a/server/licenses.go
+++ b/server/licenses.go
@@ -26,6 +26,7 @@ import (
 
 var licenseVersionConfig = entityVersionAPIConfig[vo.LicenseVO, vo.LicenseVersionVO]{
 	recordType: "license",
+	listPath:   "/licenses",
 	get: func(c *gin.Context, id string) (*vo.LicenseVO, error) {
 		return data.GetLicense(c.Request.Context(), id)
 	},
@@ -129,12 +130,12 @@ func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cach
 	g.GET("/licenses/:id/versions/:version", getEntityVersion(licenseVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.POST("/licenses", writeRoles, createEntityVersion(licenseVersionConfig))
-	g.PATCH("/licenses/:id", writeRoles, patchEntityVersion(licenseVersionConfig))
+	g.POST("/licenses", writeRoles, createEntityVersion(licenseVersionConfig, store))
+	g.PATCH("/licenses/:id", writeRoles, patchEntityVersion(licenseVersionConfig, store))
 	g.POST("/licenses/:id/versions/:version/retract", writeRoles, retractEntityVersion(licenseVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
-	g.POST("/licenses/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(licenseVersionConfig))
+	g.POST("/licenses/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(licenseVersionConfig, store))
 	g.POST("/licenses/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(licenseVersionConfig))
 	g.PATCH("/licenses/:id/volumes", reviewRoles, func(c *gin.Context) {
 		patchLicenseVolumes(c, store)

--- a/server/persons.go
+++ b/server/persons.go
@@ -24,6 +24,7 @@ import (
 
 var personVersionConfig = entityVersionAPIConfig[vo.PersonVO, vo.PersonVersionVO]{
 	recordType: "person",
+	listPath:   "/persons",
 	get: func(c *gin.Context, id string) (*vo.PersonVO, error) {
 		return data.GetPerson(c.Request.Context(), id)
 	},
@@ -76,12 +77,12 @@ func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.GET("/persons/:id/versions/:version", getEntityVersion(personVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.POST("/persons", writeRoles, createEntityVersion(personVersionConfig))
-	g.PATCH("/persons/:id", writeRoles, patchEntityVersion(personVersionConfig))
+	g.POST("/persons", writeRoles, createEntityVersion(personVersionConfig, store))
+	g.PATCH("/persons/:id", writeRoles, patchEntityVersion(personVersionConfig, store))
 	g.POST("/persons/:id/versions/:version/retract", writeRoles, retractEntityVersion(personVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
-	g.POST("/persons/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(personVersionConfig))
+	g.POST("/persons/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(personVersionConfig, store))
 	g.POST("/persons/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(personVersionConfig))
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)

--- a/server/publishers.go
+++ b/server/publishers.go
@@ -24,6 +24,7 @@ import (
 
 var publisherVersionConfig = entityVersionAPIConfig[vo.PublisherVO, vo.PublisherVersionVO]{
 	recordType: "publisher",
+	listPath:   "/publishers",
 	get: func(c *gin.Context, id string) (*vo.PublisherVO, error) {
 		return data.GetPublisher(c.Request.Context(), id)
 	},
@@ -86,12 +87,12 @@ func setupPublisherHandlers(g *gin.Engine, store persistence.CacheStore, ttls ca
 	g.GET("/publishers/:id/versions/:version", getEntityVersion(publisherVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.POST("/publishers", writeRoles, createEntityVersion(publisherVersionConfig))
-	g.PATCH("/publishers/:id", writeRoles, patchEntityVersion(publisherVersionConfig))
+	g.POST("/publishers", writeRoles, createEntityVersion(publisherVersionConfig, store))
+	g.PATCH("/publishers/:id", writeRoles, patchEntityVersion(publisherVersionConfig, store))
 	g.POST("/publishers/:id/versions/:version/retract", writeRoles, retractEntityVersion(publisherVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
-	g.POST("/publishers/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(publisherVersionConfig))
+	g.POST("/publishers/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(publisherVersionConfig, store))
 	g.POST("/publishers/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(publisherVersionConfig))
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)

--- a/server/studios.go
+++ b/server/studios.go
@@ -24,6 +24,7 @@ import (
 
 var studioVersionConfig = entityVersionAPIConfig[vo.StudioVO, vo.StudioVersionVO]{
 	recordType: "studio",
+	listPath:   "/studios",
 	get: func(c *gin.Context, id string) (*vo.StudioVO, error) {
 		return data.GetStudio(c.Request.Context(), id)
 	},
@@ -82,12 +83,12 @@ func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.GET("/studios/:id/versions/:version", getEntityVersion(studioVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.POST("/studios", writeRoles, createEntityVersion(studioVersionConfig))
-	g.PATCH("/studios/:id", writeRoles, patchEntityVersion(studioVersionConfig))
+	g.POST("/studios", writeRoles, createEntityVersion(studioVersionConfig, store))
+	g.PATCH("/studios/:id", writeRoles, patchEntityVersion(studioVersionConfig, store))
 	g.POST("/studios/:id/versions/:version/retract", writeRoles, retractEntityVersion(studioVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
-	g.POST("/studios/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(studioVersionConfig))
+	g.POST("/studios/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(studioVersionConfig, store))
 	g.POST("/studios/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(studioVersionConfig))
 	g.PATCH("/studios/:id/volumes", reviewRoles, func(c *gin.Context) {
 		patchStudioVolumes(c, store)

--- a/server/systems.go
+++ b/server/systems.go
@@ -24,6 +24,7 @@ import (
 
 var systemVersionConfig = entityVersionAPIConfig[vo.SystemVO, vo.SystemVersionVO]{
 	recordType: "system",
+	listPath:   "/systems",
 	get: func(c *gin.Context, id string) (*vo.SystemVO, error) {
 		return data.GetSystem(c.Request.Context(), id)
 	},
@@ -75,11 +76,11 @@ func setupSystemHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	g.GET("/systems/:id/versions/:version", getEntityVersion(systemVersionConfig))
 
 	writeRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor, authz.RoleSubmitter)
-	g.PATCH("/systems/:id", writeRoles, patchEntityVersion(systemVersionConfig))
+	g.PATCH("/systems/:id", writeRoles, patchEntityVersion(systemVersionConfig, store))
 	g.POST("/systems/:id/versions/:version/retract", writeRoles, retractEntityVersion(systemVersionConfig))
 
 	reviewRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin, authz.RoleEditor)
-	g.POST("/systems/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(systemVersionConfig))
+	g.POST("/systems/:id/versions/:version/accept", reviewRoles, acceptEntityVersion(systemVersionConfig, store))
 	g.POST("/systems/:id/versions/:version/reject", reviewRoles, rejectEntityVersion(systemVersionConfig))
 
 	rollbackRoles := authz.RequireAnyRole(authzClient, constants.ServiceName, authz.RoleAdmin)


### PR DESCRIPTION
createEntityVersion/patchEntityVersion/acceptEntityVersion (shared by publisher/
studio/person/license/system) never invalidated the Redis-backed GET response
cache - a newly created record, or an applied/accepted edit, stayed invisible in
that type's list/detail responses for the rest of CACHE_TTLS' window.

Concretely: a new Person shows up in catalog-web's own list cache immediately
(that side already invalidates on write), but catalog-api's own /persons response
cache doesn't - so the volume edit page's contributor autocomplete (which reads
person options fresh from catalog-api) keeps missing the new person until the
cache TTL expires.

Reuses invalidateCachedPaths from #225 rather than duplicating it.