### PR TITLE
feat: add GET /<entity>/search routes for persons, publishers, studios, licenses, systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-data.go v0.13.0
+	github.com/sweetrpg/catalog-data.go v0.14.0
 	github.com/sweetrpg/catalog-objects.go v0.4.2
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+
 github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
 github.com/sweetrpg/catalog-data.go v0.13.0 h1:8LHr7MUAkmzVYQLnYwqJWANDRtv1/5zi6zujqMdIOjg=
 github.com/sweetrpg/catalog-data.go v0.13.0/go.mod h1:PsjQ375oFP3vELIeCj6iQYorf6SlMcGVoPXqzW0XpdI=
+github.com/sweetrpg/catalog-data.go v0.14.0 h1:GmFjR3gBsw/L2uR4evJ0lX6Fs/MONsC1ktRStnA78Ig=
+github.com/sweetrpg/catalog-data.go v0.14.0/go.mod h1:PsjQ375oFP3vELIeCj6iQYorf6SlMcGVoPXqzW0XpdI=
 github.com/sweetrpg/catalog-objects.go v0.4.2 h1:yQFdc75gAicPOYx4n0lUf4MB3Q7ZPVwUEV0a/vxosA4=
 github.com/sweetrpg/catalog-objects.go v0.4.2/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=

--- a/server/licenses.go
+++ b/server/licenses.go
@@ -130,6 +130,7 @@ func setupLicenseHandlers(g *gin.Engine, store persistence.CacheStore, ttls cach
 	logging.Logger.Info("Setting up license endpoint handlers...")
 	ttl := ttls.TTL("licenses")
 	g.GET("/licenses", cache.CachePage(store, ttl, listLicenses))
+	g.GET("/licenses/search", cache.CachePage(store, ttl, searchLicenses))
 	g.GET("/licenses/:id", cache.CachePage(store, ttl, getLicense))
 	g.GET("/licenses/:id/volumes", cache.CachePage(store, ttl, getLicenseVolumes))
 	g.GET("/licenses/:id/versions", listEntityVersions(licenseVersionConfig))
@@ -167,6 +168,40 @@ func listLicenses(c *gin.Context) {
 
 	span := tracing.BuildSpanWithParams(c.Request.Context(), "licenses", "list-licenses", params)
 	vos, err := data.QueryLicenses(c.Request.Context(), params)
+	span.End()
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// Search licenses.
+//
+//	@Summary		Search licenses
+//	@Description	Finds licenses whose title contains the query string - backs autocomplete/picker inputs.
+//	@Tags			licenses
+//	@Produce		json
+//	@Param			q		query		string			true	"Search query"
+//	@Success		200		{object}	interface{}
+//	@Failure		400		{object}	interface{}
+//	@Failure		500		{object}	interface{}
+//	@Router			/licenses/search [get]
+func searchLicenses(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "q is required"})
+		return
+	}
+
+	_, span := otel.Tracer("licenses").Start(c.Request.Context(), "search-licenses", oteltrace.WithAttributes(attribute.String("q", q)))
+	vos, err := data.SearchLicenses(c.Request.Context(), q)
 	span.End()
 	if err != nil {
 		sentry.CaptureException(err)

--- a/server/persons.go
+++ b/server/persons.go
@@ -77,6 +77,7 @@ func setupPersonHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	logging.Logger.Info("Setting up person endpoint handlers...")
 	ttl := ttls.TTL("persons")
 	g.GET("/persons", cache.CachePage(store, ttl, listPersons))
+	g.GET("/persons/search", cache.CachePage(store, ttl, searchPersons))
 	g.GET("/persons/:id", cache.CachePage(store, ttl, getPerson))
 	g.GET("/persons/:id/volumes", cache.CachePage(store, ttl, getPersonVolumes))
 	g.GET("/persons/:id/versions", listEntityVersions(personVersionConfig))
@@ -123,6 +124,40 @@ func listPersons(c *gin.Context) {
 
 	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
 	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// Search persons.
+//
+//	@Summary		Search persons
+//	@Description	Finds persons whose name contains the query string - backs autocomplete/picker inputs.
+//	@Tags			persons
+//	@Produce		json
+//	@Param			q		query		string			true	"Search query"
+//	@Success		200		{object}	interface{}
+//	@Failure		400		{object}	interface{}
+//	@Failure		500		{object}	interface{}
+//	@Router			/persons/search [get]
+func searchPersons(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "q is required"})
+		return
+	}
+
+	_, span := otel.Tracer("persons").Start(c.Request.Context(), "search-persons", oteltrace.WithAttributes(attribute.String("q", q)))
+	vos, err := data.SearchPersons(c.Request.Context(), q)
+	span.End()
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	}
 }

--- a/server/publishers.go
+++ b/server/publishers.go
@@ -87,6 +87,7 @@ func setupPublisherHandlers(g *gin.Engine, store persistence.CacheStore, ttls ca
 	logging.Logger.Info("Setting up publisher endpoint handlers...")
 	ttl := ttls.TTL("publishers")
 	g.GET("/publishers", cache.CachePage(store, ttl, listPublishers))
+	g.GET("/publishers/search", cache.CachePage(store, ttl, searchPublishers))
 	g.GET("/publishers/:id", cache.CachePage(store, ttl, getPublisher))
 	g.GET("/publishers/:id/volumes", cache.CachePage(store, ttl, getPublisherVolumes))
 	g.GET("/publishers/:id/versions", listEntityVersions(publisherVersionConfig))
@@ -124,6 +125,40 @@ func listPublishers(c *gin.Context) {
 
 	span := tracing.BuildSpanWithParams(c.Request.Context(), "publishers", "list-publishers", params)
 	vos, err := data.QueryPublishers(c.Request.Context(), params)
+	span.End()
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// Search publishers.
+//
+//	@Summary		Search publishers
+//	@Description	Finds publishers whose name contains the query string - backs autocomplete/picker inputs.
+//	@Tags			publishers
+//	@Produce		json
+//	@Param			q		query		string			true	"Search query"
+//	@Success		200		{object}	interface{}
+//	@Failure		400		{object}	interface{}
+//	@Failure		500		{object}	interface{}
+//	@Router			/publishers/search [get]
+func searchPublishers(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "q is required"})
+		return
+	}
+
+	_, span := otel.Tracer("publishers").Start(c.Request.Context(), "search-publishers", oteltrace.WithAttributes(attribute.String("q", q)))
+	vos, err := data.SearchPublishers(c.Request.Context(), q)
 	span.End()
 	if err != nil {
 		sentry.CaptureException(err)

--- a/server/studios.go
+++ b/server/studios.go
@@ -83,6 +83,7 @@ func setupStudioHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	logging.Logger.Info("Setting up studio endpoint handlers...")
 	ttl := ttls.TTL("studios")
 	g.GET("/studios", cache.CachePage(store, ttl, listStudios))
+	g.GET("/studios/search", cache.CachePage(store, ttl, searchStudios))
 	g.GET("/studios/:id", cache.CachePage(store, ttl, getStudio))
 	g.GET("/studios/:id/volumes", cache.CachePage(store, ttl, getStudioVolumes))
 	g.GET("/studios/:id/versions", listEntityVersions(studioVersionConfig))
@@ -120,6 +121,40 @@ func listStudios(c *gin.Context) {
 
 	span := tracing.BuildSpanWithParams(c.Request.Context(), "studios", "list-studios", params)
 	vos, err := data.QueryStudios(c.Request.Context(), params)
+	span.End()
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// Search studios.
+//
+//	@Summary		Search studios
+//	@Description	Finds studios whose name contains the query string - backs autocomplete/picker inputs.
+//	@Tags			studios
+//	@Produce		json
+//	@Param			q		query		string			true	"Search query"
+//	@Success		200		{object}	interface{}
+//	@Failure		400		{object}	interface{}
+//	@Failure		500		{object}	interface{}
+//	@Router			/studios/search [get]
+func searchStudios(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "q is required"})
+		return
+	}
+
+	_, span := otel.Tracer("studios").Start(c.Request.Context(), "search-studios", oteltrace.WithAttributes(attribute.String("q", q)))
+	vos, err := data.SearchStudios(c.Request.Context(), q)
 	span.End()
 	if err != nil {
 		sentry.CaptureException(err)

--- a/server/systems.go
+++ b/server/systems.go
@@ -23,6 +23,7 @@ func setupSystemHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 	logging.Logger.Info("Setting up system endpoint handlers...")
 	ttl := ttls.TTL("systems")
 	g.GET("/systems", cache.CachePage(store, ttl, listSystems))
+	g.GET("/systems/search", cache.CachePage(store, ttl, searchSystems))
 	g.GET("/systems/:id", cache.CachePage(store, ttl, getSystem))
 }
 
@@ -38,6 +39,40 @@ func setupSystemHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 func listSystems(c *gin.Context) {
 	_, span := otel.Tracer("systems").Start(c.Request.Context(), "list-systems")
 	vos, err := data.QuerySystems(c.Request.Context())
+	span.End()
+	if err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
+	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
+		sentry.CaptureException(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// Search systems.
+//
+//	@Summary		Search systems
+//	@Description	Finds game systems whose name contains the query string - backs autocomplete/picker inputs.
+//	@Tags			systems
+//	@Produce		json
+//	@Param			q		query		string			true	"Search query"
+//	@Success		200		{object}	interface{}
+//	@Failure		400		{object}	interface{}
+//	@Failure		500		{object}	interface{}
+//	@Router			/systems/search [get]
+func searchSystems(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "q is required"})
+		return
+	}
+
+	_, span := otel.Tracer("systems").Start(c.Request.Context(), "search-systems", oteltrace.WithAttributes(attribute.String("q", q)))
+	vos, err := data.SearchSystems(c.Request.Context(), q)
 	span.End()
 	if err != nil {
 		sentry.CaptureException(err)


### PR DESCRIPTION
## Summary
Backs autocomplete/picker inputs on catalog-web with a real server-side search instead of
filtering a page-capped full-list fetch client-side. Bumps catalog-data.go to v0.14.0
(SearchPersons/SearchPublishers/SearchStudios/SearchLicenses/SearchSystems).

## Test plan
- [x] `go build`/`go vet`/`go test` pass locally (real MongoDB via docker)