### PR TITLE
fix(assets): forward caller's bearer token to assets-web

### DIFF
--- a/assets/client.go
+++ b/assets/client.go
@@ -42,11 +42,12 @@ type NotFoundError struct{ Kind, ID string }
 func (e NotFoundError) Error() string { return fmt.Sprintf("assets: %s/%s not found", e.Kind, e.ID) }
 
 // Get downloads an asset's bytes and content type.
-func (c *Client) Get(ctx context.Context, kind, id string) ([]byte, string, error) {
+func (c *Client) Get(ctx context.Context, token, kind, id string) ([]byte, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/asset/"+kind+"/"+id, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("assets: build get request: %w", err)
 	}
+	setBearerToken(req, token)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -69,7 +70,7 @@ func (c *Client) Get(ctx context.Context, kind, id string) ([]byte, string, erro
 }
 
 // Store uploads an asset's bytes under kind/id, overwriting any existing asset there.
-func (c *Client) Store(ctx context.Context, kind, id string, data []byte, contentType string) error {
+func (c *Client) Store(ctx context.Context, token, kind, id string, data []byte, contentType string) error {
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	header := textproto.MIMEHeader{}
@@ -93,6 +94,7 @@ func (c *Client) Store(ctx context.Context, kind, id string, data []byte, conten
 		return fmt.Errorf("assets: build store request: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
+	setBearerToken(req, token)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -108,11 +110,12 @@ func (c *Client) Store(ctx context.Context, kind, id string, data []byte, conten
 
 // Delete removes an asset. A missing asset (404) is treated as success - the end state (no
 // asset at kind/id) is the same either way.
-func (c *Client) Delete(ctx context.Context, kind, id string) error {
+func (c *Client) Delete(ctx context.Context, token, kind, id string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/asset/"+kind+"/"+id, nil)
 	if err != nil {
 		return fmt.Errorf("assets: build delete request: %w", err)
 	}
+	setBearerToken(req, token)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -129,13 +132,22 @@ func (c *Client) Delete(ctx context.Context, kind, id string) error {
 // Promote copies a staged asset (fromKind/fromID) to a live one (toKind/toID), then deletes the
 // staged copy - the promote-then-delete step every editor/admin finalize and accepted proposal
 // performs for a referenced staged cover/sample.
-func (c *Client) Promote(ctx context.Context, fromKind, fromID, toKind, toID string) error {
-	data, contentType, err := c.Get(ctx, fromKind, fromID)
+func (c *Client) Promote(ctx context.Context, token, fromKind, fromID, toKind, toID string) error {
+	data, contentType, err := c.Get(ctx, token, fromKind, fromID)
 	if err != nil {
 		return fmt.Errorf("assets: promote %s/%s -> %s/%s: %w", fromKind, fromID, toKind, toID, err)
 	}
-	if err := c.Store(ctx, toKind, toID, data, contentType); err != nil {
+	if err := c.Store(ctx, token, toKind, toID, data, contentType); err != nil {
 		return fmt.Errorf("assets: promote %s/%s -> %s/%s: %w", fromKind, fromID, toKind, toID, err)
 	}
-	return c.Delete(ctx, fromKind, fromID)
+	return c.Delete(ctx, token, fromKind, fromID)
+}
+
+// setBearerToken forwards the caller's verified user token to assets-web, which authorizes the
+// write against the same user rather than trusting this service's identity. See platform's
+// api-client-auth change (openspec/changes/api-client-auth).
+func setBearerToken(req *http.Request, token string) {
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 }

--- a/authz/middleware.go
+++ b/authz/middleware.go
@@ -12,6 +12,7 @@ import (
 const (
 	rolesContextKey   = "authz.roles"
 	subjectContextKey = "authz.subject"
+	tokenContextKey   = "authz.token"
 )
 
 // RequireAnyRole returns Gin middleware that verifies the caller's bearer token against
@@ -53,6 +54,7 @@ func RequireAnyRole(client *Client, service string, allowedRoles ...string) gin.
 
 		c.Set(rolesContextKey, result.Roles)
 		c.Set(subjectContextKey, result.Sub)
+		c.Set(tokenContextKey, token)
 		c.Next()
 	}
 }
@@ -72,6 +74,18 @@ func Subject(c *gin.Context) string {
 	if v, ok := c.Get(subjectContextKey); ok {
 		if sub, ok := v.(string); ok {
 			return sub
+		}
+	}
+	return ""
+}
+
+// Token returns the caller's verified bearer token stashed in the Gin context by
+// RequireAnyRole - forwarded onward when this service calls another one on the user's behalf
+// (e.g. assets-web's asset store), so downstream services authorize the same user.
+func Token(c *gin.Context) string {
+	if v, ok := c.Get(tokenContextKey); ok {
+		if token, ok := v.(string); ok {
+			return token
 		}
 	}
 	return ""

--- a/server/volumes_finalize.go
+++ b/server/volumes_finalize.go
@@ -81,7 +81,7 @@ func finalizeVolumeSession(
 	roles := authz.Roles(c)
 	if authz.HasRole(roles, authz.RoleAdmin) || authz.HasRole(roles, authz.RoleEditor) {
 		if session.StagedCoverAssetId != "" {
-			if err := assetsClient.Promote(c.Request.Context(), "cover-staged", session.StagedCoverAssetId, "cover", volumeID); err != nil {
+			if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "cover-staged", session.StagedCoverAssetId, "cover", volumeID); err != nil {
 				sentry.CaptureException(err)
 				c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "cover_promote_failed", Message: err.Error()})
 				return
@@ -93,7 +93,7 @@ func finalizeVolumeSession(
 			liveSampleIds := make([]string, len(session.SampleAssetIds))
 			for i, stagedID := range session.SampleAssetIds {
 				liveID := fmt.Sprintf("%s-%d", volumeID, i)
-				if err := assetsClient.Promote(c.Request.Context(), "sample-staged", stagedID, "sample", liveID); err != nil {
+				if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "sample-staged", stagedID, "sample", liveID); err != nil {
 					sentry.CaptureException(err)
 					c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "sample_promote_failed", Message: err.Error()})
 					return

--- a/server/volumes_versions.go
+++ b/server/volumes_versions.go
@@ -152,7 +152,7 @@ func acceptVolumeVersion(c *gin.Context, assetsClient *assets.Client) {
 	var liveCoverAssetId *string
 	var liveSampleAssetIds []string
 	if submitted.StagedCoverAssetId != nil {
-		if err := assetsClient.Promote(c.Request.Context(), "cover-staged", *submitted.StagedCoverAssetId, "cover", id); err != nil {
+		if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "cover-staged", *submitted.StagedCoverAssetId, "cover", id); err != nil {
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "cover_promote_failed", Message: err.Error()})
 			return
@@ -164,7 +164,7 @@ func acceptVolumeVersion(c *gin.Context, assetsClient *assets.Client) {
 		liveSampleAssetIds = make([]string, len(submitted.StagedSampleAssetIds))
 		for i, stagedID := range submitted.StagedSampleAssetIds {
 			liveID := fmt.Sprintf("%s-%d", id, i)
-			if err := assetsClient.Promote(c.Request.Context(), "sample-staged", stagedID, "sample", liveID); err != nil {
+			if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "sample-staged", stagedID, "sample", liveID); err != nil {
 				sentry.CaptureException(err)
 				c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "sample_promote_failed", Message: err.Error()})
 				return

--- a/server/volumes_write_test.go
+++ b/server/volumes_write_test.go
@@ -105,7 +105,7 @@ func seedStagedAsset(t *testing.T, deps testDeps, kind, id string, data []byte) 
 	t.Helper()
 
 	client := assets.NewClient(deps.AssetsURL)
-	if err := client.Store(t.Context(), kind, id, data, "image/png"); err != nil {
+	if err := client.Store(t.Context(), "", kind, id, data, "image/png"); err != nil {
 		t.Fatalf("seed staged asset: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- authz middleware stashes the verified bearer token; new `authz.Token(c)` accessor
- `assets.Client` Get/Store/Delete/Promote take the token and send `Authorization: Bearer`
- finalize and version-accept promote paths forward it

Part of platform's api-client-auth change (section 7). Depends on assets-web accepting forwarded tokens - deploy that first.