### PR TITLE
feat(server): structured logging across volume edit flow

### DIFF
--- a/assets/client.go
+++ b/assets/client.go
@@ -14,6 +14,7 @@ import (
 	"net/textproto"
 	"time"
 
+	"github.com/sweetrpg/common.go/logging"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -43,6 +44,7 @@ func (e NotFoundError) Error() string { return fmt.Sprintf("assets: %s/%s not fo
 
 // Get downloads an asset's bytes and content type.
 func (c *Client) Get(ctx context.Context, token, kind, id string) ([]byte, string, error) {
+	logging.Logger.Debug("assets.Get: enter", "kind", kind, "id", id)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/asset/"+kind+"/"+id, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("assets: build get request: %w", err)
@@ -51,14 +53,17 @@ func (c *Client) Get(ctx context.Context, token, kind, id string) ([]byte, strin
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		logging.Logger.Error("assets.Get: request failed", "kind", kind, "id", id, "error", err)
 		return nil, "", fmt.Errorf("assets: get request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
+		logging.Logger.Warn("assets.Get: not found", "kind", kind, "id", id)
 		return nil, "", NotFoundError{Kind: kind, ID: id}
 	}
 	if resp.StatusCode != http.StatusOK {
+		logging.Logger.Error("assets.Get: unexpected status", "kind", kind, "id", id, "status", resp.StatusCode)
 		return nil, "", fmt.Errorf("assets: unexpected status %d from get %s/%s", resp.StatusCode, kind, id)
 	}
 
@@ -66,11 +71,13 @@ func (c *Client) Get(ctx context.Context, token, kind, id string) ([]byte, strin
 	if err != nil {
 		return nil, "", fmt.Errorf("assets: read get response: %w", err)
 	}
+	logging.Logger.Debug("assets.Get: exit", "kind", kind, "id", id, "outcome", "ok")
 	return body, resp.Header.Get("Content-Type"), nil
 }
 
 // Store uploads an asset's bytes under kind/id, overwriting any existing asset there.
 func (c *Client) Store(ctx context.Context, token, kind, id string, data []byte, contentType string) error {
+	logging.Logger.Debug("assets.Store: enter", "kind", kind, "id", id)
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	header := textproto.MIMEHeader{}
@@ -98,19 +105,23 @@ func (c *Client) Store(ctx context.Context, token, kind, id string, data []byte,
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		logging.Logger.Error("assets.Store: request failed", "kind", kind, "id", id, "error", err)
 		return fmt.Errorf("assets: store request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
+		logging.Logger.Error("assets.Store: unexpected status", "kind", kind, "id", id, "status", resp.StatusCode)
 		return fmt.Errorf("assets: unexpected status %d from store %s/%s", resp.StatusCode, kind, id)
 	}
+	logging.Logger.Debug("assets.Store: exit", "kind", kind, "id", id, "outcome", "ok")
 	return nil
 }
 
 // Delete removes an asset. A missing asset (404) is treated as success - the end state (no
 // asset at kind/id) is the same either way.
 func (c *Client) Delete(ctx context.Context, token, kind, id string) error {
+	logging.Logger.Debug("assets.Delete: enter", "kind", kind, "id", id)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/asset/"+kind+"/"+id, nil)
 	if err != nil {
 		return fmt.Errorf("assets: build delete request: %w", err)
@@ -119,13 +130,16 @@ func (c *Client) Delete(ctx context.Context, token, kind, id string) error {
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		logging.Logger.Error("assets.Delete: request failed", "kind", kind, "id", id, "error", err)
 		return fmt.Errorf("assets: delete request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		logging.Logger.Error("assets.Delete: unexpected status", "kind", kind, "id", id, "status", resp.StatusCode)
 		return fmt.Errorf("assets: unexpected status %d from delete %s/%s", resp.StatusCode, kind, id)
 	}
+	logging.Logger.Debug("assets.Delete: exit", "kind", kind, "id", id, "outcome", "ok")
 	return nil
 }
 
@@ -133,14 +147,22 @@ func (c *Client) Delete(ctx context.Context, token, kind, id string) error {
 // staged copy - the promote-then-delete step every editor/admin finalize and accepted proposal
 // performs for a referenced staged cover/sample.
 func (c *Client) Promote(ctx context.Context, token, fromKind, fromID, toKind, toID string) error {
+	logging.Logger.Debug("assets.Promote: enter", "fromKind", fromKind, "fromId", fromID, "toKind", toKind, "toId", toID)
 	data, contentType, err := c.Get(ctx, token, fromKind, fromID)
 	if err != nil {
+		logging.Logger.Error("assets.Promote: get staged asset failed", "fromKind", fromKind, "fromId", fromID, "error", err)
 		return fmt.Errorf("assets: promote %s/%s -> %s/%s: %w", fromKind, fromID, toKind, toID, err)
 	}
 	if err := c.Store(ctx, token, toKind, toID, data, contentType); err != nil {
+		logging.Logger.Error("assets.Promote: store live asset failed", "toKind", toKind, "toId", toID, "error", err)
 		return fmt.Errorf("assets: promote %s/%s -> %s/%s: %w", fromKind, fromID, toKind, toID, err)
 	}
-	return c.Delete(ctx, token, fromKind, fromID)
+	if err := c.Delete(ctx, token, fromKind, fromID); err != nil {
+		logging.Logger.Error("assets.Promote: delete staged asset failed", "fromKind", fromKind, "fromId", fromID, "error", err)
+		return fmt.Errorf("assets: promote %s/%s -> %s/%s: %w", fromKind, fromID, toKind, toID, err)
+	}
+	logging.Logger.Debug("assets.Promote: exit", "fromKind", fromKind, "fromId", fromID, "toKind", toKind, "toId", toID, "outcome", "ok")
+	return nil
 }
 
 // setBearerToken forwards the caller's verified user token to assets-web, which authorizes the

--- a/editsession/store.go
+++ b/editsession/store.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/sweetrpg/common.go/logging"
 )
 
 // KeyPrefix is the Redis key namespace for edit sessions: "edit-session:<userId>:<recordType>".
@@ -45,6 +46,7 @@ func NewStore(pool *redis.Pool) *Store {
 
 // Get fetches a user's in-flight session for recordType, or nil if none exists.
 func (s *Store) Get(ctx context.Context, userID, recordType string) (*Session, error) {
+	logging.Logger.Debug("editsession.Get: enter", "userId", userID, "recordType", recordType)
 	conn, err := s.pool.GetContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("editsession: get connection: %w", err)
@@ -53,6 +55,7 @@ func (s *Store) Get(ctx context.Context, userID, recordType string) (*Session, e
 
 	raw, err := redis.Bytes(conn.Do("GET", Key(userID, recordType)))
 	if err == redis.ErrNil {
+		logging.Logger.Debug("editsession.Get: exit", "userId", userID, "recordType", recordType, "outcome", "miss")
 		return nil, nil
 	}
 	if err != nil {
@@ -63,12 +66,14 @@ func (s *Store) Get(ctx context.Context, userID, recordType string) (*Session, e
 	if err := json.Unmarshal(raw, &session); err != nil {
 		return nil, fmt.Errorf("editsession: unmarshal %s: %w", Key(userID, recordType), err)
 	}
+	logging.Logger.Debug("editsession.Get: exit", "userId", userID, "recordType", recordType, "outcome", "hit", "recordId", session.RecordID)
 	return &session, nil
 }
 
 // Set writes userID's session for recordType, overwriting any existing one. Used only by
 // pull-back (task 5.4) - every other session write comes from catalog-web directly.
 func (s *Store) Set(ctx context.Context, userID, recordType string, session Session) error {
+	logging.Logger.Debug("editsession.Set: enter", "userId", userID, "recordType", recordType)
 	conn, err := s.pool.GetContext(ctx)
 	if err != nil {
 		return fmt.Errorf("editsession: get connection: %w", err)
@@ -82,11 +87,13 @@ func (s *Store) Set(ctx context.Context, userID, recordType string, session Sess
 	if _, err := conn.Do("SET", Key(userID, recordType), raw); err != nil {
 		return fmt.Errorf("editsession: set %s: %w", Key(userID, recordType), err)
 	}
+	logging.Logger.Debug("editsession.Set: exit", "userId", userID, "recordType", recordType, "outcome", "ok")
 	return nil
 }
 
 // Delete removes a user's in-flight session for recordType. A missing session is not an error.
 func (s *Store) Delete(ctx context.Context, userID, recordType string) error {
+	logging.Logger.Debug("editsession.Delete: enter", "userId", userID, "recordType", recordType)
 	conn, err := s.pool.GetContext(ctx)
 	if err != nil {
 		return fmt.Errorf("editsession: get connection: %w", err)
@@ -96,5 +103,6 @@ func (s *Store) Delete(ctx context.Context, userID, recordType string) error {
 	if _, err := conn.Do("DEL", Key(userID, recordType)); err != nil {
 		return fmt.Errorf("editsession: delete %s: %w", Key(userID, recordType), err)
 	}
+	logging.Logger.Debug("editsession.Delete: exit", "userId", userID, "recordType", recordType, "outcome", "ok")
 	return nil
 }

--- a/editsession/store_test.go
+++ b/editsession/store_test.go
@@ -3,12 +3,19 @@ package editsession
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gomodule/redigo/redis"
+	"github.com/sweetrpg/common.go/logging"
 )
+
+func TestMain(m *testing.M) {
+	logging.Init()
+	os.Exit(m.Run())
+}
 
 func newTestPool(t *testing.T) (*redis.Pool, *miniredis.Miniredis) {
 	t.Helper()

--- a/server/entity_version_patch.go
+++ b/server/entity_version_patch.go
@@ -12,6 +12,7 @@ import (
 	apiv "github.com/sweetrpg/api-core.go/vo"
 	"github.com/sweetrpg/catalog-api/authz"
 	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/common.go/logging"
 )
 
 // entityFieldAccessor reads/writes one patchable string field on a live entity VO - used to
@@ -69,6 +70,7 @@ type entityVersionAPIConfig[T any, V any] struct {
 func createEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var entity T
+		logging.Logger.Debug("createEntityVersion: enter", "recordType", cfg.recordType)
 		if err := c.ShouldBindJSON(&entity); err != nil {
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 			return
@@ -119,6 +121,7 @@ type bulkCreateResult struct {
 func bulkCreateEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var rawEntries []json.RawMessage
+		logging.Logger.Debug("bulkCreateEntityVersion: enter", "recordType", cfg.recordType)
 		if err := c.ShouldBindJSON(&rawEntries); err != nil {
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 			return
@@ -164,6 +167,8 @@ func bulkCreateEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin
 func patchEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
+
+		logging.Logger.Debug("patchEntityVersion: enter", "recordType", cfg.recordType, "id", id)
 
 		// Bound to json.RawMessage rather than *string so a field can be either a string
 		// (cfg.fields) or an array (cfg.arrayFields, e.g. license tags) - each raw value is
@@ -282,6 +287,7 @@ func deleteEntity[T any, V any](cfg entityVersionAPIConfig[T, V], store persiste
 			return
 		}
 		if err := cfg.softDelete(c, id, authz.Subject(c)); err != nil {
+			logging.Logger.Debug("deleteEntity: enter", "recordType", cfg.recordType, "id", id)
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "delete_failed", Message: err.Error()})
 			return
@@ -306,6 +312,7 @@ func restoreEntity[T any, V any](cfg entityVersionAPIConfig[T, V], store persist
 			return
 		}
 		if err := cfg.restore(c, id); err != nil {
+			logging.Logger.Debug("restoreEntity: enter", "recordType", cfg.recordType, "id", id)
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "restore_failed", Message: err.Error()})
 			return
@@ -377,6 +384,7 @@ func acceptEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V], store p
 			return
 		}
 		var req acceptVersionRequest
+		logging.Logger.Debug("acceptEntityVersion: enter", "recordType", cfg.recordType, "id", id)
 		if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 			return
@@ -408,6 +416,7 @@ func rejectEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Han
 		}
 		var req rejectVersionRequest
 		if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+			logging.Logger.Debug("rejectEntityVersion: enter", "recordType", cfg.recordType, "id", id)
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 			return
 		}
@@ -433,6 +442,7 @@ func retractEntityVersion[T any, V any](cfg entityVersionAPIConfig[T, V]) gin.Ha
 			return
 		}
 		retracted, err := cfg.retractVersion(c, id, version, authz.Subject(c))
+		logging.Logger.Debug("retractEntityVersion: enter", "recordType", cfg.recordType, "id", id, "version", version)
 		if err != nil {
 			sentry.CaptureException(err)
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "retract_failed", Message: err.Error()})

--- a/server/reviews.go
+++ b/server/reviews.go
@@ -37,15 +37,18 @@ func setupReviewHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 //	@Router			/reviews [get]
 func listReviews(c *gin.Context) {
 	params := apiutil.GetQueryParams(c.Request.URL.RawQuery)
+	logging.Logger.Debug("listReviews: enter", "params", params)
 
 	span := tracing.BuildSpanWithParams(c.Request.Context(), "reviews", "list-reviews", params)
 	vos, err := data.QueryReviews(c.Request.Context(), params)
 	span.End()
 	if err != nil {
+		logging.Logger.Error("listReviews: query failed", "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	logging.Logger.Debug("listReviews: exit", "count", len(vos))
 
 	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
 	if err := jsonapi.MarshalPayload(c.Writer, vos); err != nil {
@@ -67,20 +70,24 @@ func listReviews(c *gin.Context) {
 //	@Router			/reviews/{id} [get]
 func getReview(c *gin.Context) {
 	id := c.Param("id")
+	logging.Logger.Debug("getReview: enter", "id", id)
 
 	_, span := otel.Tracer("reviews").Start(c.Request.Context(), "get-review", oteltrace.WithAttributes(attribute.String("id", id)))
 	vo, err := data.GetReview(c.Request.Context(), id)
 	span.End()
 	if err != nil {
+		logging.Logger.Error("getReview: query failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
 	if vo == nil {
+		logging.Logger.Debug("getReview: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, gin.H{})
 		return
 	}
+	logging.Logger.Debug("getReview: exit", "id", id, "outcome", "ok")
 
 	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
 	if err := jsonapi.MarshalPayload(c.Writer, vo); err != nil {

--- a/server/staged_assets.go
+++ b/server/staged_assets.go
@@ -32,12 +32,15 @@ type pendingStagedAssetsResponse struct {
 //	@Failure		500	{object}	apiv.ErrorVO
 //	@Router			/staged-assets/pending [get]
 func listPendingStagedAssets(c *gin.Context) {
+	logging.Logger.Debug("listPendingStagedAssets: enter")
 	pending, err := data.ListPendingStagedAssetIds(c.Request.Context())
 	if err != nil {
+		logging.Logger.Error("listPendingStagedAssets: query failed", "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
+	logging.Logger.Debug("listPendingStagedAssets: exit", "covers", len(pending.CoverAssetIds), "samples", len(pending.SampleAssetIds))
 
 	c.JSON(http.StatusOK, pendingStagedAssetsResponse{
 		CoverAssetIds:  pending.CoverAssetIds,

--- a/server/submission_cap.go
+++ b/server/submission_cap.go
@@ -44,27 +44,33 @@ type submissionCapResponse struct {
 //	@Router			/users/{userId}/submission-cap [put]
 func setSubmissionCapOverride(c *gin.Context) {
 	userID := c.Param("userId")
+	logging.Logger.Debug("setSubmissionCapOverride: enter", "userId", userID)
 
 	var req setSubmissionCapRequest
 	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		logging.Logger.Debug("setSubmissionCapOverride: exit", "userId", userID, "outcome", "bad_request")
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 		return
 	}
 
 	if req.Cap == nil {
 		if err := submissioncap.ClearOverride(c.Request.Context(), userID); err != nil {
+			logging.Logger.Error("setSubmissionCapOverride: clear override failed", "userId", userID, "error", err)
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "clear_failed", Message: err.Error()})
 			return
 		}
+		logging.Logger.Info("setSubmissionCapOverride: exit", "userId", userID, "outcome", "cleared")
 		c.JSON(http.StatusOK, submissionCapResponse{UserID: userID, Cap: submissioncap.Default()})
 		return
 	}
 
 	if err := submissioncap.SetOverride(c.Request.Context(), userID, *req.Cap); err != nil {
+		logging.Logger.Error("setSubmissionCapOverride: set override failed", "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "set_failed", Message: err.Error()})
 		return
 	}
+	logging.Logger.Info("setSubmissionCapOverride: exit", "userId", userID, "outcome", "ok", "cap", *req.Cap)
 	c.JSON(http.StatusOK, submissionCapResponse{UserID: userID, Cap: *req.Cap})
 }

--- a/server/volumes.go
+++ b/server/volumes.go
@@ -72,23 +72,28 @@ func setupVolumeHandlers(g *gin.Engine, store persistence.CacheStore, ttls cache
 //	@Router			/volumes/{id} [delete]
 func deleteVolume(c *gin.Context, store persistence.CacheStore) {
 	id := c.Param("id")
+	logging.Logger.Debug("deleteVolume: enter", "id", id)
 
 	existing, err := data.GetVolume(c.Request.Context(), id)
 	if err != nil {
+		logging.Logger.Error("deleteVolume: volume lookup failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	if existing == nil {
+		logging.Logger.Debug("deleteVolume: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, gin.H{})
 		return
 	}
 
 	if err := data.SoftDeleteVolume(c.Request.Context(), id, authz.Subject(c)); err != nil {
+		logging.Logger.Error("deleteVolume: soft delete failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	logging.Logger.Info("deleteVolume: exit", "id", id, "outcome", "ok")
 	invalidateCachedPaths(store, "/volumes", "/volumes/"+id)
 	c.Status(http.StatusNoContent)
 }
@@ -106,19 +111,23 @@ func deleteVolume(c *gin.Context, store persistence.CacheStore) {
 //	@Router			/volumes/{id}/restore [post]
 func restoreVolume(c *gin.Context, store persistence.CacheStore) {
 	id := c.Param("id")
+	logging.Logger.Debug("restoreVolume: enter", "id", id)
 
 	existing, err := data.GetVolume(c.Request.Context(), id)
 	if err != nil {
+		logging.Logger.Error("restoreVolume: volume lookup failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	if existing == nil {
+		logging.Logger.Debug("restoreVolume: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, gin.H{})
 		return
 	}
 
 	if err := data.RestoreVolume(c.Request.Context(), id); err != nil {
+		logging.Logger.Error("restoreVolume: restore failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -127,10 +136,12 @@ func restoreVolume(c *gin.Context, store persistence.CacheStore) {
 
 	result, err := data.GetVolume(c.Request.Context(), id)
 	if err != nil {
+		logging.Logger.Error("restoreVolume: post-restore query failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	logging.Logger.Info("restoreVolume: exit", "id", id, "outcome", "ok")
 	c.Writer.Header().Set("Content-type", jsonapi.MediaType)
 	if err := jsonapi.MarshalPayload(c.Writer, result); err != nil {
 		sentry.CaptureException(err)

--- a/server/volumes_finalize.go
+++ b/server/volumes_finalize.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sweetrpg/catalog-api/submissioncap"
 	"github.com/sweetrpg/catalog-data.go/data"
 	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/common.go/logging"
 )
 
 // recordTypeVolume is the edit-session recordType this endpoint reads (see docs/
@@ -41,29 +42,36 @@ func finalizeVolumeSession(
 ) {
 	volumeID := c.Param("id")
 	userID := authz.Subject(c)
+	logging.Logger.Debug("finalizeVolumeSession: enter", "volumeId", volumeID, "userId", userID)
 
 	session, err := editSessions.Get(c.Request.Context(), userID, recordTypeVolume)
 	if err != nil {
+		logging.Logger.Error("finalizeVolumeSession: session lookup failed", "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "session_lookup_failed", Message: err.Error()})
 		return
 	}
 	if session == nil {
+		logging.Logger.Warn("finalizeVolumeSession: no session found", "userId", userID, "volumeId", volumeID)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "no_session", Message: "No in-flight edit session for this volume"})
 		return
 	}
 	if session.RecordID != volumeID {
+		logging.Logger.Warn("finalizeVolumeSession: session mismatch", "userId", userID, "sessionId", session.RecordID, "requestedId", volumeID)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "session_mismatch", Message: "The in-flight session belongs to a different volume"})
 		return
 	}
+	logging.Logger.Info("finalizeVolumeSession: session found", "userId", userID, "recordId", session.RecordID)
 
 	existing, err := data.GetVolume(c.Request.Context(), volumeID)
 	if err != nil {
+		logging.Logger.Error("finalizeVolumeSession: volume lookup failed", "volumeId", volumeID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
 	if existing == nil {
+		logging.Logger.Debug("finalizeVolumeSession: exit", "volumeId", volumeID, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
@@ -74,44 +82,56 @@ func finalizeVolumeSession(
 	// reuses the PATCH role-branch below instead of introducing a second code path.
 	req, err := fieldsToPatchRequest(session.Fields)
 	if err != nil {
+		logging.Logger.Warn("finalizeVolumeSession: invalid session fields", "userId", userID, "volumeId", volumeID)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_session", Message: err.Error()})
 		return
 	}
 
 	roles := authz.Roles(c)
 	if authz.HasRole(roles, authz.RoleAdmin) || authz.HasRole(roles, authz.RoleEditor) {
+		logging.Logger.Info("finalizeVolumeSession: editor path", "userId", userID, "volumeId", volumeID)
 		if session.StagedCoverAssetId != "" {
+			logging.Logger.Info("finalizeVolumeSession: promoting staged cover", "volumeId", volumeID, "stagedCoverAssetId", session.StagedCoverAssetId)
 			if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "cover-staged", session.StagedCoverAssetId, "cover", volumeID); err != nil {
+				logging.Logger.Error("finalizeVolumeSession: staged cover promote failed", "volumeId", volumeID, "stagedCoverAssetId", session.StagedCoverAssetId, "error", err)
 				sentry.CaptureException(err)
 				c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "cover_promote_failed", Message: err.Error()})
 				return
 			}
 			coverID := volumeID
 			req.CoverAssetId = &coverID
+			logging.Logger.Info("finalizeVolumeSession: staged cover promoted", "volumeId", volumeID)
 		}
 		if len(session.SampleAssetIds) > 0 {
 			liveSampleIds := make([]string, len(session.SampleAssetIds))
 			for i, stagedID := range session.SampleAssetIds {
 				liveID := fmt.Sprintf("%s-%d", volumeID, i)
+				logging.Logger.Info("finalizeVolumeSession: promoting staged sample", "volumeId", volumeID, "stagedSampleAssetId", stagedID)
 				if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "sample-staged", stagedID, "sample", liveID); err != nil {
+					logging.Logger.Error("finalizeVolumeSession: staged sample promote failed", "volumeId", volumeID, "stagedSampleAssetId", stagedID, "error", err)
 					sentry.CaptureException(err)
 					c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "sample_promote_failed", Message: err.Error()})
 					return
 				}
 				liveSampleIds[i] = liveID
+				logging.Logger.Info("finalizeVolumeSession: staged sample promoted", "volumeId", volumeID, "liveSampleAssetId", liveID)
 			}
 			req.SampleAssetIds = &liveSampleIds
 		}
 
 		if !applyVolumePatch(c, existing, req, models.VersionStateLive, store) {
+			logging.Logger.Debug("finalizeVolumeSession: exit", "volumeId", volumeID, "outcome", "apply_failed")
 			return
 		}
 		if err := editSessions.Delete(c.Request.Context(), userID, recordTypeVolume); err != nil {
+			logging.Logger.Error("finalizeVolumeSession: session delete failed after apply", "userId", userID, "error", err)
 			sentry.CaptureException(err)
 		}
+		logging.Logger.Info("finalizeVolumeSession: exit", "volumeId", volumeID, "outcome", "editor_applied")
 		return
 	}
 
+	logging.Logger.Info("finalizeVolumeSession: submitter path", "userId", userID, "volumeId", volumeID)
 	// Submitter: check the unapproved-submission cap before creating anything - a rejected
 	// finalize must not touch the session (existing.RecordID stays theirs to retry) or count
 	// against the cap itself.
@@ -128,6 +148,7 @@ func finalizeVolumeSession(
 		return
 	}
 	if int(pendingCount) >= capValue {
+		logging.Logger.Warn("finalizeVolumeSession: submission cap reached", "userId", userID, "pending", pendingCount, "cap", capValue)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{
 			Error:   "submission_cap_reached",
 			Message: fmt.Sprintf("You have %d pending submissions, at your cap of %d - retract one before finalizing another", pendingCount, capValue),
@@ -159,19 +180,23 @@ func finalizeVolumeSession(
 
 	version, err := data.CreateSubmittedVolumeVersionWithStagedAssets(c.Request.Context(), volumeID, &updated, userID, stagedCoverAssetId, session.SampleAssetIds)
 	if err != nil {
+		logging.Logger.Error("finalizeVolumeSession: submitted version creation failed", "volumeId", volumeID, "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "propose_failed", Message: err.Error()})
 		return
 	}
 	if version == nil {
+		logging.Logger.Debug("finalizeVolumeSession: exit", "volumeId", volumeID, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
 
 	if err := editSessions.Delete(c.Request.Context(), userID, recordTypeVolume); err != nil {
+		logging.Logger.Error("finalizeVolumeSession: session delete failed after submit", "userId", userID, "error", err)
 		sentry.CaptureException(err)
 	}
 
+	logging.Logger.Info("finalizeVolumeSession: exit", "volumeId", volumeID, "userId", userID, "outcome", "submitted", "version", version.Version)
 	c.JSON(http.StatusAccepted, submittedVersionResponse{
 		Version: version.Version,
 		State:   string(version.State),

--- a/server/volumes_patch.go
+++ b/server/volumes_patch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sweetrpg/catalog-data.go/data"
 	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
 	modelcore "github.com/sweetrpg/model-core.go/vo"
 )
 
@@ -87,9 +88,11 @@ type submittedVersionResponse struct {
 //	@Router			/volumes/{id} [patch]
 func patchVolume(c *gin.Context, store persistence.CacheStore) {
 	id := c.Param("id")
+	logging.Logger.Debug("patchVolume: enter", "id", id)
 
 	var req patchVolumeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.Logger.Debug("patchVolume: exit", "id", id, "outcome", "bad_request")
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 		return
 	}
@@ -98,17 +101,20 @@ func patchVolume(c *gin.Context, store persistence.CacheStore) {
 	// comment) - without this, an editor's request touching only those fields would 400 here
 	// before ever reaching the role check below that's supposed to allow it.
 	if !req.hasSubmittableFields() && !req.hasEditorOnlyFields() {
+		logging.Logger.Debug("patchVolume: exit", "id", id, "outcome", "bad_request", "reason", "no_fields")
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: "no recognized fields to change"})
 		return
 	}
 
 	existing, err := data.GetVolume(c.Request.Context(), id)
 	if err != nil {
+		logging.Logger.Error("patchVolume: volume lookup failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
 	if existing == nil {
+		logging.Logger.Debug("patchVolume: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
@@ -117,6 +123,7 @@ func patchVolume(c *gin.Context, store persistence.CacheStore) {
 	isEditor := authz.HasRole(roles, authz.RoleAdmin) || authz.HasRole(roles, authz.RoleEditor)
 
 	if !isEditor && req.hasEditorOnlyFields() {
+		logging.Logger.Warn("patchVolume: submitter rejected editor-only fields", "id", id)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{
 			Error:   "unsupported_field",
 			Message: "properties, publisherIds, studioIds, systemIds, credits, format, coverAssetId, and sampleAssetIds can't be submitted - an editor or admin must make this change directly",
@@ -128,6 +135,7 @@ func patchVolume(c *gin.Context, store persistence.CacheStore) {
 	if isEditor {
 		state = catalogmodels.VersionStateLive
 	}
+	logging.Logger.Info("patchVolume: branch selected", "id", id, "isEditor", isEditor, "state", string(state))
 	applyVolumePatch(c, existing, req, state, store)
 }
 
@@ -149,6 +157,7 @@ func applyVolumePatch(
 	c *gin.Context, existing *vo.VolumeVO, req patchVolumeRequest, state catalogmodels.VersionState,
 	store persistence.CacheStore,
 ) bool {
+	logging.Logger.Debug("applyVolumePatch: enter", "id", existing.ID, "state", string(state))
 	updated := *existing
 	if req.Title != nil {
 		updated.Title = *req.Title
@@ -195,6 +204,7 @@ func applyVolumePatch(
 	}
 	if req.SampleAssetIds != nil {
 		if len(*req.SampleAssetIds) > maxSampleAssetIds {
+			logging.Logger.Warn("applyVolumePatch: sample limit exceeded", "id", existing.ID, "count", len(*req.SampleAssetIds), "max", maxSampleAssetIds)
 			c.JSON(http.StatusBadRequest, apiv.ErrorVO{
 				Error:   "sample_limit_exceeded",
 				Message: fmt.Sprintf("a volume may have at most %d samples", maxSampleAssetIds),
@@ -207,6 +217,7 @@ func applyVolumePatch(
 
 	if req.Credits != nil {
 		if err := applyCreditsDiff(c, existing.ID, *req.Credits, updated.UpdatedBy); err != nil {
+			logging.Logger.Error("applyVolumePatch: credits diff failed", "id", existing.ID, "error", err)
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "update_failed", Message: err.Error()})
 			return false
@@ -215,16 +226,19 @@ func applyVolumePatch(
 
 	version, err := data.UpdateVolume(c.Request.Context(), existing.ID, &updated, state)
 	if err != nil {
+		logging.Logger.Error("applyVolumePatch: update failed", "id", existing.ID, "state", string(state), "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "update_failed", Message: err.Error()})
 		return false
 	}
 	if version == nil {
+		logging.Logger.Debug("applyVolumePatch: exit", "id", existing.ID, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return false
 	}
 
 	if state != catalogmodels.VersionStateLive {
+		logging.Logger.Info("applyVolumePatch: submitted version created", "id", existing.ID, "version", version.Version, "updatedBy", updated.UpdatedBy)
 		c.JSON(http.StatusAccepted, submittedVersionResponse{
 			Version: version.Version,
 			State:   string(version.State),
@@ -233,12 +247,15 @@ func applyVolumePatch(
 		return true
 	}
 
+	logging.Logger.Info("applyVolumePatch: live version applied", "id", existing.ID, "version", version.Version, "updatedBy", updated.UpdatedBy)
+
 	if req.PublisherIDs != nil || req.StudioIDs != nil || req.SystemIDs != nil {
 		invalidateVolumeAssociationCache(store, existing, &updated)
 	}
 
 	result, err := data.GetVolume(c.Request.Context(), existing.ID)
 	if err != nil {
+		logging.Logger.Error("applyVolumePatch: post-update query failed", "id", existing.ID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return false
@@ -249,6 +266,7 @@ func applyVolumePatch(
 	if err := jsonapi.MarshalPayload(c.Writer, result); err != nil {
 		sentry.CaptureException(err)
 	}
+	logging.Logger.Debug("applyVolumePatch: exit", "id", existing.ID, "outcome", "ok")
 	return true
 }
 
@@ -259,6 +277,7 @@ func applyVolumePatch(
 // (predating credits, or created some other way) is left untouched even if none of its roles
 // match, since it isn't representable as one desired pair.
 func applyCreditsDiff(c *gin.Context, volumeID string, desired []creditRequest, updatedBy string) error {
+	logging.Logger.Debug("applyCreditsDiff: enter", "volumeId", volumeID, "desired", len(desired), "updatedBy", updatedBy)
 	existing, err := data.QueryContributionsByVolume(c.Request.Context(), volumeID)
 	if err != nil {
 		return err
@@ -295,5 +314,6 @@ func applyCreditsDiff(c *gin.Context, volumeID string, desired []creditRequest, 
 			return err
 		}
 	}
+	logging.Logger.Debug("applyCreditsDiff: exit", "volumeId", volumeID, "outcome", "ok")
 	return nil
 }

--- a/server/volumes_versions.go
+++ b/server/volumes_versions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sweetrpg/catalog-api/authz"
 	"github.com/sweetrpg/catalog-api/editsession"
 	"github.com/sweetrpg/catalog-data.go/data"
+	"github.com/sweetrpg/common.go/logging"
 )
 
 // acceptVersionRequest mirrors acceptProposalRequest for the version-based accept action.
@@ -55,13 +56,16 @@ func versionParam(c *gin.Context) (int, bool) {
 //	@Router			/volumes/{id}/versions [get]
 func listVolumeVersions(c *gin.Context) {
 	id := c.Param("id")
+	logging.Logger.Debug("listVolumeVersions: enter", "id", id)
 
 	versions, err := data.ListVolumeVersions(c.Request.Context(), id)
 	if err != nil {
+		logging.Logger.Error("listVolumeVersions: query failed", "id", id, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
+	logging.Logger.Debug("listVolumeVersions: exit", "id", id, "count", len(versions))
 
 	c.JSON(http.StatusOK, versions)
 }
@@ -85,17 +89,21 @@ func getVolumeVersion(c *gin.Context) {
 	if !ok {
 		return
 	}
+	logging.Logger.Debug("getVolumeVersion: enter", "id", id, "version", version)
 
 	result, err := data.GetVolumeVersion(c.Request.Context(), id, version)
 	if err != nil {
+		logging.Logger.Error("getVolumeVersion: query failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
 	if result == nil {
+		logging.Logger.Debug("getVolumeVersion: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
+	logging.Logger.Debug("getVolumeVersion: exit", "id", id, "version", version, "outcome", "ok")
 
 	c.JSON(http.StatusOK, result)
 }
@@ -121,9 +129,11 @@ func acceptVolumeVersion(c *gin.Context, assetsClient *assets.Client) {
 	if !ok {
 		return
 	}
+	logging.Logger.Debug("acceptVolumeVersion: enter", "id", id, "version", version)
 
 	var req acceptVersionRequest
 	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		logging.Logger.Debug("acceptVolumeVersion: exit", "id", id, "outcome", "bad_request")
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "invalid_request", Message: err.Error()})
 		return
 	}
@@ -135,11 +145,13 @@ func acceptVolumeVersion(c *gin.Context, assetsClient *assets.Client) {
 
 	submitted, err := data.GetVolumeVersion(c.Request.Context(), id, version)
 	if err != nil {
+		logging.Logger.Error("acceptVolumeVersion: version lookup failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
 	if submitted == nil {
+		logging.Logger.Debug("acceptVolumeVersion: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
@@ -152,34 +164,42 @@ func acceptVolumeVersion(c *gin.Context, assetsClient *assets.Client) {
 	var liveCoverAssetId *string
 	var liveSampleAssetIds []string
 	if submitted.StagedCoverAssetId != nil {
+		logging.Logger.Info("acceptVolumeVersion: promoting staged cover", "id", id, "version", version, "stagedCoverAssetId", *submitted.StagedCoverAssetId)
 		if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "cover-staged", *submitted.StagedCoverAssetId, "cover", id); err != nil {
+			logging.Logger.Error("acceptVolumeVersion: staged cover promote failed", "id", id, "version", version, "stagedCoverAssetId", *submitted.StagedCoverAssetId, "error", err)
 			sentry.CaptureException(err)
 			c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "cover_promote_failed", Message: err.Error()})
 			return
 		}
 		coverID := id
 		liveCoverAssetId = &coverID
+		logging.Logger.Info("acceptVolumeVersion: staged cover promoted", "id", id, "version", version)
 	}
 	if len(submitted.StagedSampleAssetIds) > 0 {
 		liveSampleAssetIds = make([]string, len(submitted.StagedSampleAssetIds))
 		for i, stagedID := range submitted.StagedSampleAssetIds {
 			liveID := fmt.Sprintf("%s-%d", id, i)
+			logging.Logger.Info("acceptVolumeVersion: promoting staged sample", "id", id, "version", version, "stagedSampleAssetId", stagedID)
 			if err := assetsClient.Promote(c.Request.Context(), authz.Token(c), "sample-staged", stagedID, "sample", liveID); err != nil {
+				logging.Logger.Error("acceptVolumeVersion: staged sample promote failed", "id", id, "version", version, "stagedSampleAssetId", stagedID, "error", err)
 				sentry.CaptureException(err)
 				c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "sample_promote_failed", Message: err.Error()})
 				return
 			}
 			liveSampleAssetIds[i] = liveID
+			logging.Logger.Info("acceptVolumeVersion: staged sample promoted", "id", id, "version", version, "liveSampleAssetId", liveID)
 		}
 	}
 
 	accepted, conflicts, err := data.AcceptVolumeVersion(c.Request.Context(), id, version, selectedFields, authz.Subject(c), nil, liveCoverAssetId, liveSampleAssetIds)
 	if err != nil {
+		logging.Logger.Error("acceptVolumeVersion: accept failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "accept_failed", Message: err.Error()})
 		return
 	}
 
+	logging.Logger.Info("acceptVolumeVersion: exit", "id", id, "version", version, "outcome", "ok", "conflicts", len(conflicts))
 	c.JSON(http.StatusOK, reviewVersionResponse{
 		Version:   accepted.Version,
 		State:     string(accepted.State),
@@ -208,6 +228,7 @@ func rejectVolumeVersion(c *gin.Context) {
 	if !ok {
 		return
 	}
+	logging.Logger.Debug("rejectVolumeVersion: enter", "id", id, "version", version)
 
 	var req rejectVersionRequest
 	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
@@ -221,11 +242,13 @@ func rejectVolumeVersion(c *gin.Context) {
 	}
 
 	if err := data.RejectVolumeVersion(c.Request.Context(), id, version, authz.Subject(c), note); err != nil {
+		logging.Logger.Error("rejectVolumeVersion: reject failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "reject_failed", Message: err.Error()})
 		return
 	}
 
+	logging.Logger.Info("rejectVolumeVersion: exit", "id", id, "version", version, "outcome", "ok")
 	c.JSON(http.StatusOK, reviewVersionResponse{Version: version, State: "rejected"})
 }
 
@@ -248,13 +271,16 @@ func retractVolumeVersion(c *gin.Context) {
 	if !ok {
 		return
 	}
+	logging.Logger.Debug("retractVolumeVersion: enter", "id", id, "version", version)
 
 	retracted, err := data.RetractVolumeVersion(c.Request.Context(), id, version, authz.Subject(c))
 	if err != nil {
+		logging.Logger.Error("retractVolumeVersion: retract failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "retract_failed", Message: err.Error()})
 		return
 	}
+	logging.Logger.Info("retractVolumeVersion: exit", "id", id, "version", version, "outcome", "ok")
 
 	c.JSON(http.StatusOK, reviewVersionResponse{Version: retracted.Version, State: string(retracted.State)})
 }
@@ -286,25 +312,30 @@ func pullBackVolumeVersion(c *gin.Context, editSessions *editsession.Store) {
 		return
 	}
 	userID := authz.Subject(c)
+	logging.Logger.Debug("pullBackVolumeVersion: enter", "id", id, "version", version, "userId", userID)
 
 	submitted, err := data.GetVolumeVersion(c.Request.Context(), id, version)
 	if err != nil {
+		logging.Logger.Error("pullBackVolumeVersion: version lookup failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "query_failed", Message: err.Error()})
 		return
 	}
 	if submitted == nil {
+		logging.Logger.Debug("pullBackVolumeVersion: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
 
 	existingSession, err := editSessions.Get(c.Request.Context(), userID, recordTypeVolume)
 	if err != nil {
+		logging.Logger.Error("pullBackVolumeVersion: session lookup failed", "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "session_lookup_failed", Message: err.Error()})
 		return
 	}
 	if existingSession != nil {
+		logging.Logger.Warn("pullBackVolumeVersion: session already exists", "userId", userID)
 		c.JSON(http.StatusConflict, apiv.ErrorVO{
 			Error:   "session_exists",
 			Message: "You already have an in-flight edit session for this record type - finish or discard it before pulling back a submission",
@@ -330,6 +361,7 @@ func pullBackVolumeVersion(c *gin.Context, editSessions *editsession.Store) {
 		UpdatedAt:          now,
 	}
 	if err := editSessions.Set(c.Request.Context(), userID, recordTypeVolume, session); err != nil {
+		logging.Logger.Error("pullBackVolumeVersion: session create failed", "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "session_create_failed", Message: err.Error()})
 		return
@@ -344,11 +376,13 @@ func pullBackVolumeVersion(c *gin.Context, editSessions *editsession.Store) {
 		if delErr := editSessions.Delete(c.Request.Context(), userID, recordTypeVolume); delErr != nil {
 			sentry.CaptureException(delErr)
 		}
+		logging.Logger.Error("pullBackVolumeVersion: retract failed after session creation, session rolled back", "id", id, "version", version, "userId", userID, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusInternalServerError, apiv.ErrorVO{Error: "pull_back_failed", Message: err.Error()})
 		return
 	}
 
+	logging.Logger.Info("pullBackVolumeVersion: exit", "id", id, "version", version, "userId", userID, "outcome", "ok")
 	c.JSON(http.StatusOK, pullBackVersionResponse{RecordID: retracted.RecordID, Status: string(retracted.State)})
 }
 
@@ -371,17 +405,21 @@ func setCurrentVolumeVersion(c *gin.Context) {
 	if !ok {
 		return
 	}
+	logging.Logger.Debug("setCurrentVolumeVersion: enter", "id", id, "version", version)
 
 	result, err := data.SetCurrentVolumeVersion(c.Request.Context(), id, version)
 	if err != nil {
+		logging.Logger.Error("setCurrentVolumeVersion: rollback failed", "id", id, "version", version, "error", err)
 		sentry.CaptureException(err)
 		c.JSON(http.StatusBadRequest, apiv.ErrorVO{Error: "rollback_failed", Message: err.Error()})
 		return
 	}
 	if result == nil {
+		logging.Logger.Debug("setCurrentVolumeVersion: exit", "id", id, "outcome", "not_found")
 		c.JSON(http.StatusNotFound, apiv.ErrorVO{})
 		return
 	}
+	logging.Logger.Info("setCurrentVolumeVersion: exit", "id", id, "version", version, "outcome", "ok")
 
 	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
Adds slog entry/exit (Debug) and decision-point (Info/Warn/Error) logging to the volume PATCH/finalize/review handlers, staged-assets, submission-cap, assets client, and editsession store, to make 400s in the volume-edit-with-staged-cover flow traceable. Adds TestMain so editsession tests init the logger.