### PR TITLE
feat(cmd): ensure license/person/publisher/studio versioning indexes at startup

### DIFF
--- a/cmd/catalog-api/main.go
+++ b/cmd/catalog-api/main.go
@@ -112,6 +112,19 @@ func main() {
 	if err := data.EnsureVolumeVersioningIndexes(context.Background()); err != nil {
 		logging.Logger.Error("Error while ensuring volume versioning indexes", "error", err.Error())
 	}
+	for _, ensure := range []struct {
+		name string
+		fn   func(context.Context) error
+	}{
+		{"license", data.EnsureLicenseVersioningIndexes},
+		{"person", data.EnsurePersonVersioningIndexes},
+		{"publisher", data.EnsurePublisherVersioningIndexes},
+		{"studio", data.EnsureStudioVersioningIndexes},
+	} {
+		if err := ensure.fn(context.Background()); err != nil {
+			logging.Logger.Error("Error while ensuring versioning indexes", "entity", ensure.name, "error", err.Error())
+		}
+	}
 	if err := vocabularies.Backfill(context.Background()); err != nil {
 		logging.Logger.Error("Error while backfilling vocabularies", "error", err.Error())
 	}


### PR DESCRIPTION
Wires up the existing EnsureLicense/Person/Publisher/StudioVersioningIndexes functions from catalog-data.go at startup - previously only the volume one was called, so those versions collections had no record_id+version / record_id+state indexes.