### PR TITLE
feat(volumes): support tags on volume PATCH and finalize-session

### DIFF
--- a/server/volumes_finalize.go
+++ b/server/volumes_finalize.go
@@ -14,8 +14,9 @@ import (
 	"github.com/sweetrpg/catalog-api/editsession"
 	"github.com/sweetrpg/catalog-api/submissioncap"
 	"github.com/sweetrpg/catalog-data.go/data"
-	"github.com/sweetrpg/catalog-objects.go/models"
+	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/vo"
 )
 
 // recordTypeVolume is the edit-session recordType this endpoint reads (see docs/
@@ -77,7 +78,7 @@ func finalizeVolumeSession(
 	}
 
 	// session.Fields round-trips through patchVolumeRequest's own JSON tags (title,
-	// description, notes, properties, publisherIds, studioIds, credits, format) rather than
+	// description, notes, tags, properties, publisherIds, studioIds, credits, format) rather than
 	// hand-unmarshaling each key - the two shapes are deliberately the same, since finalize
 	// reuses the PATCH role-branch below instead of introducing a second code path.
 	req, err := fieldsToPatchRequest(session.Fields)
@@ -119,7 +120,7 @@ func finalizeVolumeSession(
 			req.SampleAssetIds = &liveSampleIds
 		}
 
-		if !applyVolumePatch(c, existing, req, models.VersionStateLive, store) {
+		if !applyVolumePatch(c, existing, req, catalogmodels.VersionStateLive, store) {
 			logging.Logger.Debug("finalizeVolumeSession: exit", "volumeId", volumeID, "outcome", "apply_failed")
 			return
 		}
@@ -170,6 +171,13 @@ func finalizeVolumeSession(
 	}
 	if req.Notes != nil {
 		updated.Notes = *req.Notes
+	}
+	if req.Tags != nil {
+		tags := make([]modelcore.TagVO, len(*req.Tags))
+		for i, name := range *req.Tags {
+			tags[i] = modelcore.TagVO{Name: name}
+		}
+		updated.Tags = tags
 	}
 	updated.UpdatedBy = userID
 

--- a/server/volumes_patch.go
+++ b/server/volumes_patch.go
@@ -45,6 +45,7 @@ type patchVolumeRequest struct {
 	Title          *string            `json:"title"`
 	Description    *string            `json:"description"`
 	Notes          *string            `json:"notes"`
+	Tags           *[]string          `json:"tags"`
 	Properties     *[]propertyRequest `json:"properties"`
 	PublisherIDs   *[]string          `json:"publisherIds"`
 	StudioIDs      *[]string          `json:"studioIds"`
@@ -140,10 +141,11 @@ func patchVolume(c *gin.Context, store persistence.CacheStore) {
 }
 
 // hasSubmittableFields reports whether req touches a field a submitter is allowed to change
-// directly (title/description/notes) - the fields patchRequestDiff used to diff before the
-// version model made per-field diffing unnecessary.
+// directly (title/description/notes/tags - tags are free-text labels, same policy as license
+// tags) - the fields patchRequestDiff used to diff before the version model made per-field
+// diffing unnecessary.
 func (req patchVolumeRequest) hasSubmittableFields() bool {
-	return req.Title != nil || req.Description != nil || req.Notes != nil
+	return req.Title != nil || req.Description != nil || req.Notes != nil || req.Tags != nil
 }
 
 // applyVolumePatch merges req's present fields into existing and creates a new version with the
@@ -167,6 +169,13 @@ func applyVolumePatch(
 	}
 	if req.Notes != nil {
 		updated.Notes = *req.Notes
+	}
+	if req.Tags != nil {
+		tags := make([]modelcore.TagVO, len(*req.Tags))
+		for i, name := range *req.Tags {
+			tags[i] = modelcore.TagVO{Name: name}
+		}
+		updated.Tags = tags
 	}
 	if req.Properties != nil {
 		props := make([]modelcore.PropertyVO, len(*req.Properties))


### PR DESCRIPTION
- patchVolumeRequest gains a Tags field, merged into the version snapshot as Name-only TagVOs; submittable by any write role (same policy as license tags)
- finalizeVolumeSession's submitter path now merges tags too, so submitter tag edits aren't dropped
- session fields already round-trip through the PATCH body, so no other finalize changes needed