### PR TITLE
Set GOMEMLIMIT and GOGC for catalog-api

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -56,7 +56,11 @@ spec:
                             name: api-misc
                       - secretRef:
                             name: api-cache
-                  env: []
+                  env:
+                      - name: GOMEMLIMIT
+                        value: "900MiB"
+                      - name: GOGC
+                        value: "100"
                   ports:
                       - containerPort: 8000
                         name: http


### PR DESCRIPTION
Add GOMEMLIMIT=900MiB and GOGC=100 to the app container's env list in
kubernetes/base/deployment.yaml so the Go GC pacer respects the container's 1Gi memory limit
(90% headroom) instead of relying on GOGC's heap-growth ratio alone.

Closes #256