### PR TITLE
Tighten GOGC to 90 for catalog-api

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                       - name: GOMEMLIMIT
                         value: "900MiB"
                       - name: GOGC
-                        value: "100"
+                        value: "90"
                   ports:
                       - containerPort: 8000
                         name: http


### PR DESCRIPTION
Change GOGC from 100 to 90 on the app container's env in kubernetes/base/deployment.yaml.
90 collects somewhat more eagerly than the Go runtime default, trading a bit of CPU for a lower
average heap and more headroom before GOMEMLIMIT itself has to intervene.